### PR TITLE
:sparkles: XS2-118 WorkspaceController 클래스 구조 작성 및 엔티티 수정

### DIFF
--- a/src/main/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiController.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiController.java
@@ -1,0 +1,26 @@
+package com.prgrms.be02slack.workspace.controller;
+
+import com.prgrms.be02slack.workspace.controller.dto.WorkspaceUpdateRequest;
+import com.prgrms.be02slack.workspace.service.WorkspaceService;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/workspaces")
+public class WorkspaceApiController {
+
+  private final WorkspaceService workspaceService;
+
+  public WorkspaceApiController(WorkspaceService workspaceService) {
+    this.workspaceService = workspaceService;
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/workspace/entity/Workspace.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/entity/Workspace.java
@@ -1,10 +1,13 @@
 package com.prgrms.be02slack.workspace.entity;
 
 import com.prgrms.be02slack.common.entity.BaseTime;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 @Entity
 public class Workspace extends BaseTime {
@@ -13,6 +16,18 @@ public class Workspace extends BaseTime {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @NotNull
+  @Size(min = 1, max = 50)
   private String name;
 
+  @NotNull
+  @Size(min = 1, max = 21)
+  private String url;
+
+  protected Workspace() {/*no-op*/}
+
+  public Workspace(String name, String url) {
+    this.name = name;
+    this.url = url;
+  }
 }

--- a/src/main/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceService.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceService.java
@@ -1,0 +1,14 @@
+package com.prgrms.be02slack.workspace.service;
+
+import com.prgrms.be02slack.workspace.entity.Workspace;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class DefaultWorkspaceService implements WorkspaceService {
+
+  @Override
+  public void update(String key, Workspace workspace) {
+
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/service/WorkspaceService.java
@@ -1,0 +1,5 @@
+package com.prgrms.be02slack.workspace.service;
+
+public interface WorkspaceService {
+
+}

--- a/src/test/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiControllerTest.java
+++ b/src/test/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiControllerTest.java
@@ -1,0 +1,16 @@
+package com.prgrms.be02slack.workspace.controller;
+
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.MockBeans;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+
+@WebMvcTest(controllers = WorkspaceApiController.class)
+@MockBeans({@MockBean(JpaMetamodelMappingContext.class)})
+@AutoConfigureRestDocs
+class WorkspaceApiControllerTest {
+
+  private static final String API_URL = "/api/v1/workspace";
+
+}


### PR DESCRIPTION
1. create update 구현 을 재희님과 제가 나눠서 작성하기 위해서 공통되는 부분만 먼저 작성하였습니다.

2. workspace 에 url부분을 추가하였습니다.

url 은 https:// 랑 slack.com 과 같이 공통되는 부분은 DB에 저장되지 않는것으로 보고 아래와 같이 수정한 부분(asdfasd)만 저장하도록 하겠습니다.

![image](https://user-images.githubusercontent.com/28651727/174775028-342cadb8-ea0b-45eb-8ff7-4356ae4e3223.png)

![image](https://user-images.githubusercontent.com/28651727/174775043-9245df72-9668-4205-b0c6-f8cf1998148e.png)

3. name과 url의 길이는 슬랙에서 확인후 동일하게 제약조건 걸어주었습니다