### PR TITLE
XS2-57 WorkspaceApiController - update 메서드 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,18 @@ plugins {
     id 'org.springframework.boot' version '2.6.8'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id "org.asciidoctor.convert" version "1.5.9.2"
+}
+
+asciidoctor {
+    dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from("./build/asciidoc/html5") {
+        into 'static/docs'
+    }
 }
 
 group = 'com.prgrms'
@@ -22,6 +34,7 @@ dependencies {
     runtimeOnly 'mysql:mysql-connector-java'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.6.8'
     testImplementation 'org.springframework.security:spring-security-test:5.7.1'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:2.0.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiController.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiController.java
@@ -1,8 +1,14 @@
 package com.prgrms.be02slack.workspace.controller;
 
+import javax.validation.Valid;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.prgrms.be02slack.workspace.controller.dto.WorkspaceUpdateRequest;
 import com.prgrms.be02slack.workspace.service.WorkspaceService;
 
 @RestController
@@ -14,4 +20,14 @@ public class WorkspaceApiController {
   public WorkspaceApiController(WorkspaceService workspaceService) {
     this.workspaceService = workspaceService;
   }
+
+  @PutMapping("{key}")
+  public void update(
+      @PathVariable String key,
+      @Valid @RequestBody WorkspaceUpdateRequest request
+  ) {
+    final var workspace = WorkspaceUpdateRequest.toEntity(request);
+    workspaceService.update(key, workspace);
+  }
+
 }

--- a/src/main/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiController.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiController.java
@@ -22,10 +22,7 @@ public class WorkspaceApiController {
   }
 
   @PutMapping("{key}")
-  public void update(
-      @PathVariable String key,
-      @Valid @RequestBody WorkspaceUpdateRequest request
-  ) {
+  public void update(@PathVariable String key, @Valid @RequestBody WorkspaceUpdateRequest request) {
     final var workspace = WorkspaceUpdateRequest.toEntity(request);
     workspaceService.update(key, workspace);
   }

--- a/src/main/java/com/prgrms/be02slack/workspace/controller/dto/WorkspaceUpdateRequest.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/controller/dto/WorkspaceUpdateRequest.java
@@ -1,0 +1,34 @@
+package com.prgrms.be02slack.workspace.controller.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+import com.prgrms.be02slack.workspace.entity.Workspace;
+
+public class WorkspaceUpdateRequest {
+
+  @NotBlank
+  @Size(min = 1, max = 50)
+  private final String name;
+
+  @NotBlank
+  @Size(min = 1, max = 21)
+  private final String url;
+
+  public WorkspaceUpdateRequest(String name, String url) {
+    this.name = name;
+    this.url = url;
+  }
+
+  public static Workspace toEntity(WorkspaceUpdateRequest request) {
+    return new Workspace(request.getName(), request.getUrl());
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceService.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceService.java
@@ -2,7 +2,13 @@ package com.prgrms.be02slack.workspace.service;
 
 import org.springframework.stereotype.Service;
 
+import com.prgrms.be02slack.workspace.entity.Workspace;
+
 @Service
 public class DefaultWorkspaceService implements WorkspaceService {
 
+  @Override
+  public void update(String key, Workspace workspace) {
+
+  }
 }

--- a/src/main/java/com/prgrms/be02slack/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/service/WorkspaceService.java
@@ -1,5 +1,8 @@
 package com.prgrms.be02slack.workspace.service;
 
+import com.prgrms.be02slack.workspace.entity.Workspace;
+
 public interface WorkspaceService {
 
+  void update(String key, Workspace workspace);
 }

--- a/src/test/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiControllerTest.java
+++ b/src/test/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiControllerTest.java
@@ -7,7 +7,6 @@ import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.HashMap;
-import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
@@ -92,10 +91,9 @@ class WorkspaceApiControllerTest {
       void ItResponseOk() throws Exception {
         //given
         final var workspaceKey = "testKey";
-        final var requestMap = Map.of(
-            "name", "testName",
-            "url", "testUrl"
-        );
+        final var requestMap = new HashMap<>();
+        requestMap.put("name", "testName");
+        requestMap.put("url", "testUrl");
         final var requestBody = objectMapper.writeValueAsString(requestMap);
 
         //when

--- a/src/test/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiControllerTest.java
+++ b/src/test/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiControllerTest.java
@@ -1,16 +1,186 @@
 package com.prgrms.be02slack.workspace.controller;
 
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.MockBeans;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = WorkspaceApiController.class)
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.be02slack.workspace.entity.Workspace;
+import com.prgrms.be02slack.workspace.service.WorkspaceService;
+
+@WebMvcTest(
+    controllers = WorkspaceApiController.class,
+    excludeAutoConfiguration = SecurityAutoConfiguration.class
+)
 @MockBeans({@MockBean(JpaMetamodelMappingContext.class)})
 @AutoConfigureRestDocs
 class WorkspaceApiControllerTest {
 
-  private static final String API_URL = "/api/v1/workspace";
+  private static final String API_URL = "/api/v1/workspaces";
 
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private WorkspaceService workspaceService;
+
+  static class NameSourceOutOfRange implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          Arguments.of((Object)null),
+          Arguments.of(""),
+          Arguments.of("\t"),
+          Arguments.of("\n"),
+          Arguments.of("a".repeat(51))
+      );
+    }
+  }
+
+  static class UrlSourceOutOfRange implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          Arguments.of((Object)null),
+          Arguments.of(""),
+          Arguments.of("\t"),
+          Arguments.of("\n"),
+          Arguments.of("a".repeat(22))
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("update 메서드는")
+  class DescribeUpdate {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("Ok 를 응답한다")
+      void ItResponseOk() throws Exception {
+        //given
+        final var workspaceKey = "testKey";
+        final var requestMap = Map.of(
+            "name", "testName",
+            "url", "testUrl"
+        );
+        final var requestBody = objectMapper.writeValueAsString(requestMap);
+
+        //when
+        final var request =
+            RestDocumentationRequestBuilders.put(API_URL + "/{key}", workspaceKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody);
+
+        final var response = mockMvc.perform(request);
+
+        //then
+        verify(workspaceService).update(anyString(), any(Workspace.class));
+        response.andExpect(status().isOk())
+            .andDo(document("Update workspace",
+                pathParameters(
+                    parameterWithName("key").description("workspace key")
+                ),
+                requestFields(
+                    fieldWithPath("name")
+                        .type(JsonFieldType.STRING)
+                        .description("workspace name"),
+                    fieldWithPath("url")
+                        .type(JsonFieldType.STRING)
+                        .description("work space url")
+                )
+            ));
+      }
+    }
+
+    @Nested
+    @DisplayName("name 의 길이가 범위를 벗어나면")
+    class ContextWithNameOutOfRange {
+
+      @ParameterizedTest
+      @ArgumentsSource(NameSourceOutOfRange.class)
+      @DisplayName("BadRequest 를 응답한다")
+      void ItResponseBadRequest(String name) throws Exception {
+        //given
+        final var workspaceKey = "testKey";
+
+        final var requestMap = new HashMap<>();
+        requestMap.put("name", name);
+        requestMap.put("url", "testUrl");
+        final var requestBody = objectMapper.writeValueAsString(requestMap);
+
+        //when
+        final var request =
+            RestDocumentationRequestBuilders.put(API_URL + "/{key}", workspaceKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody);
+
+        final var response = mockMvc.perform(request);
+
+        //then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("Url 의 길이가 범위를 벗어나면")
+    class ContextWithUrlOutOfRange {
+
+      @ParameterizedTest
+      @ArgumentsSource(UrlSourceOutOfRange.class)
+      @DisplayName("BadRequest 를 응답한다")
+      void ItResponseBadRequest(String url) throws Exception {
+        //given
+        final var workspaceKey = "testKey";
+
+        final var requestMap = new HashMap<>();
+        requestMap.put("name", "testName");
+        requestMap.put("url", url);
+        final var requestBody = objectMapper.writeValueAsString(requestMap);
+
+        //when
+        final var request =
+            RestDocumentationRequestBuilders.put(API_URL + "/{key}", workspaceKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody);
+
+        final var response = mockMvc.perform(request);
+
+        //then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+  }
 }


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용

1. RestDocs 적용을 위해 디펜던시를 추가하였습니다.

2. Security 의존성으로 인해 테스트시에 403 에러가 발생하여서 WebMvc 테스트에서 `excludeAutoConfiguration = SecurityAutoConfiguration.class` 속성을 통해 시큐리티 관련 설정을 배제하고 구현하였습니다.

3. 해당부분은 JwtAuthenticationFilter 가 구현되면 토큰에따라 수정할 계획입니다.

4. 긴 문자열에 대해 Validation을 진행해야하는데 (ex, name : 51자가 넘는 경우, url : 22자가 넘는 경우) 이경우 긴 문자열을 코드에 집어 넣으면 가독성이 떨어져서 ArgumentsProvider를 상속한 클래스를 구현한후 특정문자열("a") 에 repeat 메서드를 적용하여 구현하였습니다.

## ✅ PR 포인트 & 궁금한 점

key 부분은 이전 PR #3 에서 언급했듯 workspace 엔티티의 prime key의 해시값으로 할 예정인데요
ex) 1 (prime key) --- (hash function) ---> T0222P65KHN

![image](https://user-images.githubusercontent.com/28651727/174985024-7fbca5d1-030e-4635-9768-939fbce233e7.png)

실제 슬랙에서 사용하는것과 동일한 길이를 output으로 내는 해시함수는 찾기가 어려웠고 적당한해시함수를 몇가지 추려보았습니다. 어떤것으로 하는것이 좋을지 각자 의견내주시면 감사하겠습니다!

### 후보

#### 1. MD5

과정 : 1  (prime key) --- (MD5) ---> c4ca4238a0b923820dcc509a6f75849b

예시 : https://ray.slack.com/client/c4ca4238a0b923820dcc509a6f75849b/{channelKey}

#### 2. CRC 32

과정 : 1 (prime key) --- (CRC 32) ---> 83dcefb7

예시 : https://ray.slack.com/client/83dcefb7/{channelKey}


