### PR TITLE
Xs2-123 id 값 인코딩을 위한 HashUtil 구현

### DIFF
--- a/src/main/java/com/prgrms/be02slack/common/util/IdEncoder.java
+++ b/src/main/java/com/prgrms/be02slack/common/util/IdEncoder.java
@@ -1,0 +1,45 @@
+package com.prgrms.be02slack.common.util;
+
+import static org.apache.logging.log4j.util.Strings.*;
+
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+public class IdEncoder {
+  private static final String CODEC = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  private static final String CODEC_PATTERN = "^[ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789]*$";
+  private final int RADIX = 36;
+
+  public String encode(long id) {
+    Assert.isTrue(id > 0, "Id must be positive");
+
+    long param = id == Long.MAX_VALUE ? id : Long.MAX_VALUE - id;
+    StringBuilder sb = new StringBuilder();
+    while (param > 0) {
+      sb.append(CODEC.charAt((int)(param % RADIX)));
+      param /= RADIX;
+    }
+    return sb.toString();
+  }
+
+  public long decode(String param) {
+    Assert.isTrue(isNotBlank(param), "Invalid hash value");
+    Assert.isTrue(isValidHashVal(param), "Invalid hash value");
+
+    long sum = 0;
+    long power = 1;
+    for (int i = 0; i < param.length(); i++) {
+      sum += CODEC.indexOf(param.charAt(i)) * power;
+      power *= RADIX;
+    }
+    return Long.MAX_VALUE - sum;
+  }
+
+  private boolean isValidHashVal(String param) {
+    return Pattern.matches(CODEC_PATTERN, param);
+  }
+}
+

--- a/src/test/java/com/prgrms/be02slack/common/util/IdEncoderTest.java
+++ b/src/test/java/com/prgrms/be02slack/common/util/IdEncoderTest.java
@@ -1,0 +1,87 @@
+package com.prgrms.be02slack.common.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+class IdEncoderTest {
+
+  private final IdEncoder idEncoder = new IdEncoder();
+  private final Logger log = LoggerFactory.getLogger(IdEncoderTest.class);
+
+  @Nested
+  @Order(1)
+  @DisplayName("encode 메서드는")
+  class DescribeEncode {
+
+    @Nested
+    @DisplayName("양수 값이 전달되면")
+    class ContextWithPositiveValue {
+
+      @ParameterizedTest
+      @ValueSource(longs = {1, Long.MAX_VALUE})
+      @DisplayName("해시 값을 반환한다")
+      void ItReturnHashValue(long src) {
+        final var encoded = idEncoder.encode(src);
+        log.info(encoded);
+      }
+    }
+
+    @Nested
+    @DisplayName("양수가 아닌 값이 전달되면")
+    class ContextWithNotPositive {
+
+      @ParameterizedTest
+      @ValueSource(longs = {0, -1, Long.MIN_VALUE})
+      @DisplayName("IllegalArgumentException 에러를 반환한다")
+      void ItThrowsIllegalArgumentException(long src) {
+        assertThrows(IllegalArgumentException.class, () -> idEncoder.encode(src));
+      }
+    }
+  }
+
+  @Nested
+  @Order(2)
+  @DisplayName("decode 메서드는")
+  class DescribeDecode {
+
+    @Nested
+    @DisplayName("인코딩된 값이 전달되면")
+    class ContextWithHashValue {
+
+      @Test
+      @DisplayName("디코딩된 값을 반환한다")
+      void ItReturnsDecodedValue() {
+        final var testId = 1000L;
+        final var encoded = idEncoder.encode(testId);
+
+        final var decoded = idEncoder.decode(encoded);
+        assertEquals(testId, decoded);
+      }
+    }
+
+    @Nested
+    @DisplayName("유효하지 않은 해시값이 전달되면")
+    class ContextWithNullOrEmpty {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\n", "\t", "", " ", "aa", "1a2s"})
+      @DisplayName("IllegalArgumentException 에러를 발생시킨다")
+      void ItThrowsIllegalArgumentException(String src) {
+        assertThrows(IllegalArgumentException.class, () -> idEncoder.decode(src));
+      }
+    }
+  }
+}


### PR DESCRIPTION
기존에 제가 언급했던 CRC32 나 MD5 같은경우는 양방향 알고리즘이 아니기도하고, 기존 슬랙에서 사용하는 형식 그대로 사용하고 싶어서 최대한 비슷하게 인코딩 함수를 구현해 보았습니다. 

다음과 같은 형태의 인코딩값이 나오게 됩니다.

- GOIOCDTSAZC8B
- HOIOCDTSAZC8B

--
해시 -> 인코딩 단어수정하겠습니다.

