### PR TITLE
XS2-122 : DefaultWorkspaceService 워크스페이스 업데이트 메서드 구현

### DIFF
--- a/src/main/java/com/prgrms/be02slack/common/exception/NotFoundException.java
+++ b/src/main/java/com/prgrms/be02slack/common/exception/NotFoundException.java
@@ -1,0 +1,10 @@
+package com.prgrms.be02slack.common.exception;
+
+public class NotFoundException extends RuntimeException {
+  public NotFoundException() {
+  }
+
+  public NotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/workspace/entity/Workspace.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/entity/Workspace.java
@@ -1,11 +1,15 @@
 package com.prgrms.be02slack.workspace.entity;
 
+import static org.apache.logging.log4j.util.Strings.*;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+
+import org.springframework.util.Assert;
 
 import com.prgrms.be02slack.common.entity.BaseTime;
 
@@ -27,12 +31,17 @@ public class Workspace extends BaseTime {
   protected Workspace() {/*no-op*/}
 
   public Workspace(String name, String url) {
+    Assert.isTrue(isNotBlank(name), "Name must be provided");
+    Assert.isTrue(isNotBlank(url), "Url must be provided");
+
     this.name = name;
     this.url = url;
   }
 
-  public void update(Workspace workspace) {
-    this.name = workspace.url;
-    this.url = workspace.url;
+  public void update(Workspace updateWorkspace) {
+    Assert.notNull(updateWorkspace, "Workspace must be provided");
+
+    this.name = updateWorkspace.url;
+    this.url = updateWorkspace.url;
   }
 }

--- a/src/main/java/com/prgrms/be02slack/workspace/entity/Workspace.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/entity/Workspace.java
@@ -30,4 +30,9 @@ public class Workspace extends BaseTime {
     this.name = name;
     this.url = url;
   }
+
+  public void update(Workspace workspace) {
+    this.name = workspace.url;
+    this.url = workspace.url;
+  }
 }

--- a/src/main/java/com/prgrms/be02slack/workspace/repository/WorkspaceRepository.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/repository/WorkspaceRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.be02slack.workspace.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.prgrms.be02slack.workspace.entity.Workspace;
+
+public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
+}

--- a/src/main/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceService.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceService.java
@@ -1,14 +1,41 @@
 package com.prgrms.be02slack.workspace.service;
 
-import org.springframework.stereotype.Service;
+import static org.apache.logging.log4j.util.Strings.*;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import com.prgrms.be02slack.common.exception.NotFoundException;
+import com.prgrms.be02slack.common.util.IdEncoder;
 import com.prgrms.be02slack.workspace.entity.Workspace;
+import com.prgrms.be02slack.workspace.repository.WorkspaceRepository;
 
 @Service
+@Transactional
 public class DefaultWorkspaceService implements WorkspaceService {
+
+  private final IdEncoder idEncoder;
+  private final WorkspaceRepository workspaceRepository;
+
+  public DefaultWorkspaceService(
+      IdEncoder idEncoder,
+      WorkspaceRepository workspaceRepository
+  ) {
+    this.idEncoder = idEncoder;
+    this.workspaceRepository = workspaceRepository;
+  }
 
   @Override
   public void update(String key, Workspace workspace) {
+    Assert.isTrue(isNotBlank(key), "Key must be provided");
+    Assert.notNull(workspace, "Workspace must be provided");
 
+    final var id = idEncoder.decode(key);
+
+    final var saved = workspaceRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException("Workspace not found"));
+
+    saved.update(workspace);
   }
 }

--- a/src/main/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceService.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceService.java
@@ -27,15 +27,15 @@ public class DefaultWorkspaceService implements WorkspaceService {
   }
 
   @Override
-  public void update(String key, Workspace workspace) {
+  public void update(String key, Workspace updateWorkspace) {
     Assert.isTrue(isNotBlank(key), "Key must be provided");
-    Assert.notNull(workspace, "Workspace must be provided");
+    Assert.notNull(updateWorkspace, "Workspace must be provided");
 
     final var id = idEncoder.decode(key);
 
     final var saved = workspaceRepository.findById(id)
         .orElseThrow(() -> new NotFoundException("Workspace not found"));
 
-    saved.update(workspace);
+    saved.update(updateWorkspace);
   }
 }

--- a/src/main/java/com/prgrms/be02slack/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/service/WorkspaceService.java
@@ -4,5 +4,5 @@ import com.prgrms.be02slack.workspace.entity.Workspace;
 
 public interface WorkspaceService {
 
-  void update(String key, Workspace workspace);
+  void update(String key, Workspace updateWorkspace);
 }

--- a/src/test/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceServiceTest.java
@@ -1,0 +1,113 @@
+package com.prgrms.be02slack.workspace.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.prgrms.be02slack.common.exception.NotFoundException;
+import com.prgrms.be02slack.common.util.IdEncoder;
+import com.prgrms.be02slack.workspace.entity.Workspace;
+import com.prgrms.be02slack.workspace.repository.WorkspaceRepository;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultWorkspaceServiceTest {
+
+  @Mock
+  private IdEncoder idEncoder;
+
+  @Mock
+  private WorkspaceRepository workspaceRepository;
+
+  @InjectMocks
+  private DefaultWorkspaceService defaultWorkspaceService;
+
+  @Nested
+  @DisplayName("update 메서드는")
+  class DescribeUpdate {
+
+    @Nested
+    @DisplayName("빈 키 값이 전달되면")
+    class ContextWithBlankKey {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\n", "\t", "", " "})
+      @DisplayName("IllegalArgumentException 에러를 발생시킨다")
+      void ItThrowsIllegalArgumentException(String src) {
+        final var testWorkspace = new Workspace("test", "test");
+        assertThrows(IllegalArgumentException.class,
+            () -> defaultWorkspaceService.update(src, testWorkspace));
+      }
+    }
+
+    @Nested
+    @DisplayName("workspace 파라미터에 null 값이 전달되면")
+    class ContextWithWorkspaceNull {
+
+      @Test
+      @DisplayName("IllegalArgumentException 에러를 발생시킨다")
+      void ItThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class,
+            () -> defaultWorkspaceService.update("testKey", null));
+      }
+    }
+
+    @Nested
+    @DisplayName("key 값에 해당하는 workspace 가 존재하지 않는 경우")
+    class ContextWithNotExistWorkspace {
+
+      @Test
+      @DisplayName("NotFoundException 에러를 발생시킨다")
+      void ItThrowsNotfoundException() {
+        //given
+        final var workspace = new Workspace("test", "test");
+        given(idEncoder.decode(anyString())).willReturn(1L);
+        given(workspaceRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class,
+            () -> defaultWorkspaceService.update("test", workspace));
+      }
+    }
+
+    @Nested
+    @DisplayName("key 값에 해당하는 workspace 가 존재하는 경우")
+    class ContextWithExistWorkspace {
+
+      @Test
+      @DisplayName("해당 workspace 내용을 업데이트 한다")
+      void It() {
+        //given
+        final var updateWorkspace = new Workspace("update", "update");
+        final var existWorkspace = new Workspace("exist", "exist");
+
+        given(idEncoder.decode(anyString())).willReturn(1L);
+        given(workspaceRepository.findById(anyLong())).willReturn(Optional.of(existWorkspace));
+
+        //when
+        defaultWorkspaceService.update("test", updateWorkspace);
+
+        //then
+        final var name = (String)ReflectionTestUtils.getField(existWorkspace, "name");
+        final var url = (String)ReflectionTestUtils.getField(existWorkspace, "url");
+
+        assertEquals("update", name);
+        assertEquals("update", url);
+      }
+    }
+  }
+}


### PR DESCRIPTION
- url의 파라미터로 전달된 키값을 디코딩한 후 디코딩한 id값을 조회하고
- 해당엔티티를 전달된 엔티티의 내용으로 업데이트 하도록 구현하였습니다.
- 커스텀 예외는 보통 NotFoundException 만 만드는 편이라, 추가적으로 커스텀 예외만들일은 없을것 같습니다. 