### PR TITLE
XS2-127 멤버 이메일, 워크스페이스로 조회하는 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/be02slack/member/entity/Member.java
+++ b/src/main/java/com/prgrms/be02slack/member/entity/Member.java
@@ -89,4 +89,8 @@ public class Member extends BaseTime {
       return new Member(this);
     }
   }
+
+  public static Builder builder() {
+    return new Builder();
+  }
 }

--- a/src/main/java/com/prgrms/be02slack/member/repository/MemberRepository.java
+++ b/src/main/java/com/prgrms/be02slack/member/repository/MemberRepository.java
@@ -1,0 +1,14 @@
+package com.prgrms.be02slack.member.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.workspace.entity.Workspace;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+  Optional<Member> findByEmailAndWorkspace(String email, Workspace workspace);
+
+}

--- a/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
@@ -1,0 +1,36 @@
+package com.prgrms.be02slack.member.service;
+
+import static org.apache.logging.log4j.util.Strings.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import com.prgrms.be02slack.common.exception.NotFoundException;
+import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.member.repository.MemberRepository;
+import com.prgrms.be02slack.workspace.service.WorkspaceService;
+
+@Service
+public class DefaultMemberService implements MemberService {
+
+  private final MemberRepository memberRepository;
+  private final WorkspaceService workspaceService;
+
+  public DefaultMemberService(
+      MemberRepository memberRepository,
+      WorkspaceService workspaceService
+  ) {
+    this.memberRepository = memberRepository;
+    this.workspaceService = workspaceService;
+  }
+
+  public Member findByEmailAndWorkspaceKey(String key, String email) {
+    Assert.isTrue(isNotBlank(key), "Key must be provided");
+    Assert.isTrue(isNotBlank(email), "Workspace must be provided");
+
+    final var findWorkspace = workspaceService.findByKey(key);
+
+    return memberRepository.findByEmailAndWorkspace(email, findWorkspace)
+        .orElseThrow(() -> new NotFoundException("member notfound"));
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/member/service/DefaultWorkspaceService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/DefaultWorkspaceService.java
@@ -1,7 +1,0 @@
-package com.prgrms.be02slack.member.service;
-
-import org.springframework.stereotype.Service;
-
-@Service
-public class DefaultWorkspaceService implements MemberService {
-}

--- a/src/main/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceService.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceService.java
@@ -38,4 +38,14 @@ public class DefaultWorkspaceService implements WorkspaceService {
 
     saved.update(updateWorkspace);
   }
+
+  @Override
+  public Workspace findByKey(String key) {
+    Assert.isTrue(isNotBlank(key), "Key must be provided");
+
+    final var id = idEncoder.decode(key);
+
+    return workspaceRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException("Workspace not found"));
+  }
 }

--- a/src/main/java/com/prgrms/be02slack/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/service/WorkspaceService.java
@@ -5,4 +5,6 @@ import com.prgrms.be02slack.workspace.entity.Workspace;
 public interface WorkspaceService {
 
   void update(String key, Workspace updateWorkspace);
+
+  Workspace findByKey(String key);
 }

--- a/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
@@ -1,0 +1,125 @@
+package com.prgrms.be02slack.member.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.prgrms.be02slack.common.exception.NotFoundException;
+import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.member.entity.Role;
+import com.prgrms.be02slack.member.repository.MemberRepository;
+import com.prgrms.be02slack.workspace.entity.Workspace;
+import com.prgrms.be02slack.workspace.service.WorkspaceService;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultMemberServiceTest {
+
+  @Mock
+  MemberRepository repository;
+
+  @Mock
+  WorkspaceService workspaceService;
+
+  @InjectMocks
+  DefaultMemberService memberService;
+
+  @Nested
+  @DisplayName("FindByEmailAndWorkspace 메서드는")
+  class DescribeFindByEmailAndWorkspace {
+
+    @Nested
+    @DisplayName("존재하지 않는 멤버 email 값을 인자로 받으면")
+    class ContextWithNotExistEmail {
+
+      @Test
+      @DisplayName("Throw NotfoundException")
+      void ItThrowNotFoundException() {
+
+        final String email = "notfound@exception.com";
+        final String key = "ABC123ABC";
+        final Workspace findWorkspace = new Workspace("test", "test");
+
+        when(workspaceService.findByKey(key)).thenReturn(findWorkspace);
+        when(repository.findByEmailAndWorkspace(email, findWorkspace)).thenReturn(Optional.empty());
+
+        Assertions.assertThatThrownBy(() -> memberService.findByEmailAndWorkspaceKey(key, email))
+            .isInstanceOf(NotFoundException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("key가 비어있는 인자를 받으면")
+    class ContextWithKeyNullAndEmptySource {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\t", "\n"})
+      @DisplayName("IllegalArgumentException 을 반환한다.")
+      void ItThrowIllegalArgumentException(String key) {
+        final String email = "test@test.com";
+        Assertions.assertThatThrownBy(() -> memberService.findByEmailAndWorkspaceKey(key, email))
+            .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("email이 비어있는 인자를 받으면")
+    class ContextWithEmailNullAndEmptySource {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\t", "\n"})
+      @DisplayName("IllegalArgumentException 을 반환한다.")
+      void ItThrowIllegalArgumentException(String email) {
+        final String key = "AAAADB24";
+        Assertions.assertThatThrownBy(() -> memberService.findByEmailAndWorkspaceKey(key, email))
+            .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("존재하는 멤버 email 값을 인자로 받으면")
+    class ContextWithExistEmail {
+
+      @Test
+      @DisplayName("해당 멤버를 반환한다")
+      void ItThrowNotFoundException() {
+        //given
+        final var savedEmail = "test@naver.com";
+
+        final var findWorkspace = new Workspace("test", "test");
+        final var savedMember = Member.builder().name("test")
+            .workspace(findWorkspace)
+            .email(savedEmail)
+            .displayName("test")
+            .role(Role.USER)
+            .build();
+
+        given(workspaceService.findByKey(anyString())).willReturn(findWorkspace);
+        given(repository.findByEmailAndWorkspace(anyString(), any(Workspace.class)))
+            .willReturn(Optional.of(savedMember));
+
+        //when
+        final var foundMember = memberService.findByEmailAndWorkspaceKey("test", savedEmail);
+
+        //then
+        final var foundMemberEmail = ReflectionTestUtils.getField(foundMember, "email");
+        assertEquals(savedEmail, foundMemberEmail);
+      }
+    }
+  }
+}

--- a/src/test/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceServiceTest.java
@@ -110,4 +110,65 @@ class DefaultWorkspaceServiceTest {
       }
     }
   }
+
+  @Nested
+  @DisplayName("findByKey 메서드는")
+  class DescribeFindByKey {
+
+    @Nested
+    @DisplayName("빈값이 전달되면")
+    class ContextWithNullOrEmptyString {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\n", "\t", "", ""})
+      @DisplayName("IllegalArgumentException 에러를 던진다")
+      void ItThrowsIllegalArgumentException(String src) {
+        assertThrows(IllegalArgumentException.class, () -> defaultWorkspaceService.findByKey(src));
+      }
+    }
+
+    @Nested
+    @DisplayName("빈값이 아닌 값이 전달되고, 값이 존재하면")
+    class ContextWithExist {
+
+      @Test
+      @DisplayName("해당 값을 디코딩한 id값 을 가진 엔티티를 반환한다")
+      void ItReturnWorkspace() {
+        //given
+        final var savedWorkspaceName = "test";
+        final var savedWorkspaceUrl = "test";
+        final var savedWorkspace = new Workspace(savedWorkspaceName, savedWorkspaceUrl);
+        given(idEncoder.decode(anyString())).willReturn(1L);
+        given(workspaceRepository.findById(anyLong())).willReturn(Optional.of(savedWorkspace));
+
+        //when
+        final var foundWorkspace = defaultWorkspaceService.findByKey("ABC123ABC123");
+
+        //then
+        final var foundWorkspaceName = ReflectionTestUtils.getField(foundWorkspace, "name");
+        final var foundWorkspaceUrl = ReflectionTestUtils.getField(foundWorkspace, "url");
+        assertEquals(savedWorkspaceName, foundWorkspaceName);
+        assertEquals(savedWorkspaceUrl, foundWorkspaceUrl);
+
+      }
+    }
+
+    @Nested
+    @DisplayName("빈값이 아닌 값이 전달되고, 값이 존재하지 않으면")
+    class ContextWithNotExist {
+
+      @Test
+      @DisplayName("해당 값을 디코딩한 id값 을 가진 엔티티를 반환한다")
+      void ItReturnWorkspace() {
+        //given
+        given(idEncoder.decode(anyString())).willReturn(1L);
+        given(workspaceRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        //when, then
+        assertThrows(IllegalArgumentException.class,
+            () -> defaultWorkspaceService.findByKey("ABC123ABC123"));
+      }
+    }
+  }
 }


### PR DESCRIPTION
## 🧗구현 내용
- DefaultWorkspaceService - findByKey 메서드 : key 값을 디코딩하여 workspace 조회
- DefaultMemberService - findByEmailAndWorkspaceKey : DefaultWorkspaceService 를 통해 Workspace를 조회한 후, 해당 Workspace와, 인자로 받은 Email 을 통해 MemberRepository에서 Member 조회