### PR TITLE
XS2-135 - 채널이름 생성시 채널이름과 멤버이름의 중복 확인을 하는 메서드

### DIFF
--- a/src/main/java/com/prgrms/be02slack/member/entity/Member.java
+++ b/src/main/java/com/prgrms/be02slack/member/entity/Member.java
@@ -93,8 +93,4 @@ public class Member extends BaseTime {
   public static Builder builder() {
     return new Builder();
   }
-
-  public String getName() {
-    return name;
-  }
 }

--- a/src/main/java/com/prgrms/be02slack/member/entity/Member.java
+++ b/src/main/java/com/prgrms/be02slack/member/entity/Member.java
@@ -93,4 +93,8 @@ public class Member extends BaseTime {
   public static Builder builder() {
     return new Builder();
   }
+
+  public String getName() {
+    return name;
+  }
 }

--- a/src/main/java/com/prgrms/be02slack/member/repository/MemberRepository.java
+++ b/src/main/java/com/prgrms/be02slack/member/repository/MemberRepository.java
@@ -11,4 +11,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Optional<Member> findByEmailAndWorkspace(String email, Workspace workspace);
 
+  Optional<Member> findByNameAndWorkspace(String name, Workspace workspace);
 }

--- a/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
@@ -25,22 +25,22 @@ public class DefaultMemberService implements MemberService {
   }
 
   @Override
-  public Member findByEmailAndWorkspaceKey(String key, String email) {
-    Assert.isTrue(isNotBlank(key), "Key must be provided");
+  public Member findByEmailAndWorkspaceKey(String encodedWorkspaceId, String email) {
+    Assert.isTrue(isNotBlank(encodedWorkspaceId), "id must be provided");
     Assert.isTrue(isNotBlank(email), "email must be provided");
 
-    final var findWorkspace = workspaceService.findByKey(key);
+    final var findWorkspace = workspaceService.findByKey(encodedWorkspaceId);
 
     return memberRepository.findByEmailAndWorkspace(email, findWorkspace)
         .orElseThrow(() -> new NotFoundException("member notfound"));
   }
 
   @Override
-  public boolean checkMemberName(String key, String channelName) {
-    Assert.isTrue(isNotBlank(key), "Key must be provided");
+  public boolean isDuplicatedMemberName(String encodedWorkspaceId, String channelName) {
+    Assert.isTrue(isNotBlank(encodedWorkspaceId), "id must be provided");
     Assert.isTrue(isNotBlank(channelName), "channelName must be provided");
 
-    final var workspace = workspaceService.findByKey(key);
+    final var workspace = workspaceService.findByKey(encodedWorkspaceId);
 
     return memberRepository.findByNameAndWorkspace(channelName, workspace)
             .isEmpty();

--- a/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
@@ -36,11 +36,11 @@ public class DefaultMemberService implements MemberService {
   }
 
   @Override
-  public boolean checkMemberName(String workspaceKey, String channelName) {
-    Assert.isTrue(isNotBlank(workspaceKey), "Key must be provided");
+  public boolean checkMemberName(String key, String channelName) {
+    Assert.isTrue(isNotBlank(key), "Key must be provided");
     Assert.isTrue(isNotBlank(channelName), "channelName must be provided");
 
-    final var workspace = workspaceService.findByKey(workspaceKey);
+    final var workspace = workspaceService.findByKey(key);
 
     return memberRepository.findByNameAndWorkspace(channelName, workspace)
             .isEmpty();

--- a/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
@@ -24,13 +24,25 @@ public class DefaultMemberService implements MemberService {
     this.workspaceService = workspaceService;
   }
 
+  @Override
   public Member findByEmailAndWorkspaceKey(String key, String email) {
     Assert.isTrue(isNotBlank(key), "Key must be provided");
-    Assert.isTrue(isNotBlank(email), "Workspace must be provided");
+    Assert.isTrue(isNotBlank(email), "email must be provided");
 
     final var findWorkspace = workspaceService.findByKey(key);
 
     return memberRepository.findByEmailAndWorkspace(email, findWorkspace)
         .orElseThrow(() -> new NotFoundException("member notfound"));
+  }
+
+  @Override
+  public boolean checkMemberName(String workspaceKey, String channelName) {
+    Assert.isTrue(isNotBlank(workspaceKey), "Key must be provided");
+    Assert.isTrue(isNotBlank(channelName), "channelName must be provided");
+
+    final var workspace = workspaceService.findByKey(workspaceKey);
+
+    return memberRepository.findByNameAndWorkspace(channelName, workspace)
+            .isEmpty();
   }
 }

--- a/src/main/java/com/prgrms/be02slack/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/MemberService.java
@@ -6,5 +6,5 @@ public interface MemberService {
 
   Member findByEmailAndWorkspaceKey(String key, String email);
 
-  boolean checkMemberName(String workspaceKey, String channelName);
+  boolean isDuplicatedMemberName(String encodedWorkspaceId, String channelName);
 }

--- a/src/main/java/com/prgrms/be02slack/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/MemberService.java
@@ -5,4 +5,6 @@ import com.prgrms.be02slack.member.entity.Member;
 public interface MemberService {
 
   Member findByEmailAndWorkspaceKey(String key, String email);
+
+  boolean checkMemberName(String workspaceKey, String channelName);
 }

--- a/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
@@ -122,4 +122,90 @@ class DefaultMemberServiceTest {
       }
     }
   }
+
+  @Nested
+  @DisplayName("checkMemberName 메서드는")
+  class DescribeCheckMemberName {
+
+    @Nested
+    @DisplayName("비어있는 key값을 인자로 받으면")
+    class ContextNullEmptyKeyArgument {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\t", "\n"})
+      @DisplayName("IllegalArgumentException을 던진다.")
+      void itTrowIllegalArgumentException(String workspacekey) {
+        //given
+        final String channelName = "ABC123";
+
+        //then
+        Assertions.assertThatThrownBy(
+                () -> memberService.checkMemberName(workspacekey, channelName))
+            .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("비어있는 channelName값을 인자로 받으면")
+    class ContextNullEmptyNameArgument {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\t", "\n"})
+      @DisplayName("IllegalArgumentException을 던진다.")
+      void itTrowIllegalArgumentException(String channelName) {
+        //given
+        final String validWorkspaceKey = "ABC123";
+
+        //then
+        Assertions.assertThatThrownBy(
+                () -> memberService.checkMemberName(validWorkspaceKey, channelName))
+            .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("유효한 workspacekey와 channelName값을 인자로 받으면")
+    class ContextValidArgument {
+
+      @Test
+      @DisplayName("해당 이름을 가진 사용자가 존재할 경우 false를 반환한다.")
+      void itReturnFalse() {
+        //given
+        final String validWorkspaceKey = "ABC123";
+        final String validChannelName = "hello";
+        final Optional<Member> member = Optional.of(
+            Member.builder()
+                .name("test")
+                .build()
+        );
+
+        when(repository.findByNameAndWorkspace(any(), any())).thenReturn(member);
+
+        //when
+        final boolean expected = memberService.checkMemberName(validWorkspaceKey, validChannelName);
+
+        //then
+        Assertions.assertThat(false).isEqualTo(expected);
+      }
+
+      @Test
+      @DisplayName("해당 이름을 가진 사용자가 존재하지 않을 경우 true를 반환한다.")
+      void itReturnTrue() {
+        //given
+        final String validWorkspaceKey = "ABC123";
+        final String validChannelName = "hello";
+        final Optional<Member> member = Optional.empty();
+
+        when(repository.findByNameAndWorkspace(any(), any())).thenReturn(member);
+
+        //when
+        final boolean expected = memberService.checkMemberName(validWorkspaceKey, validChannelName);
+
+        //then
+        Assertions.assertThat(true).isEqualTo(expected);
+      }
+    }
+  }
 }

--- a/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
@@ -141,7 +141,7 @@ class DefaultMemberServiceTest {
 
         //then
         Assertions.assertThatThrownBy(
-                () -> memberService.checkMemberName(workspacekey, channelName))
+                () -> memberService.isDuplicatedMemberName(workspacekey, channelName))
             .isInstanceOf(IllegalArgumentException.class);
       }
     }
@@ -160,7 +160,7 @@ class DefaultMemberServiceTest {
 
         //then
         Assertions.assertThatThrownBy(
-                () -> memberService.checkMemberName(validWorkspaceKey, channelName))
+                () -> memberService.isDuplicatedMemberName(validWorkspaceKey, channelName))
             .isInstanceOf(IllegalArgumentException.class);
       }
     }
@@ -184,7 +184,8 @@ class DefaultMemberServiceTest {
         when(repository.findByNameAndWorkspace(any(), any())).thenReturn(member);
 
         //when
-        final boolean expected = memberService.checkMemberName(validWorkspaceKey, validChannelName);
+        final boolean expected =
+            memberService.isDuplicatedMemberName(validWorkspaceKey, validChannelName);
 
         //then
         Assertions.assertThat(false).isEqualTo(expected);
@@ -201,7 +202,8 @@ class DefaultMemberServiceTest {
         when(repository.findByNameAndWorkspace(any(), any())).thenReturn(member);
 
         //when
-        final boolean expected = memberService.checkMemberName(validWorkspaceKey, validChannelName);
+        final boolean expected =
+            memberService.isDuplicatedMemberName(validWorkspaceKey, validChannelName);
 
         //then
         Assertions.assertThat(true).isEqualTo(expected);


### PR DESCRIPTION
채널 이름 생성시 채널 이름과 워크스페이스 key를 받아 중복을 체크하는 MemberService의메서드 입니다!

JpaRepository의 메서드 네이밍에 맞게 잘 했는지 확인해주시면 감사할것 같습니다.

