### PR TITLE
XS2-37 : 로그인(이메일 인증) 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'com.sun.mail:javax.mail:1.6.2'
     implementation 'org.springframework.boot:spring-boot-starter-mail:2.5.1'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.6.8'

--- a/src/main/java/com/prgrms/be02slack/Application.java
+++ b/src/main/java/com/prgrms/be02slack/Application.java
@@ -2,9 +2,13 @@ package com.prgrms.be02slack;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import com.prgrms.be02slack.common.configuration.security.JwtConfig;
+
 @EnableJpaAuditing
+@EnableConfigurationProperties(JwtConfig.class)
 @SpringBootApplication
 public class Application {
 

--- a/src/main/java/com/prgrms/be02slack/common/configuration/security/JwtConfig.java
+++ b/src/main/java/com/prgrms/be02slack/common/configuration/security/JwtConfig.java
@@ -1,27 +1,24 @@
 package com.prgrms.be02slack.common.configuration.security;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
-@Component
 @ConfigurationProperties(prefix = "jwt")
+@ConstructorBinding
 public class JwtConfig {
-  private String tokenSecret;
-  private long tokenExpirationMsec;
+  private final String tokenSecret;
+  private final long tokenExpirationMsec;
+
+  public JwtConfig(String tokenSecret, long tokenExpirationMsec) {
+    this.tokenSecret = tokenSecret;
+    this.tokenExpirationMsec = tokenExpirationMsec;
+  }
 
   public String getTokenSecret() {
     return tokenSecret;
   }
 
-  public void setTokenSecret(String tokenSecret) {
-    this.tokenSecret = tokenSecret;
-  }
-
   public long getTokenExpirationMsec() {
     return tokenExpirationMsec;
-  }
-
-  public void setTokenExpirationMsec(long tokenExpirationMsec) {
-    this.tokenExpirationMsec = tokenExpirationMsec;
   }
 }

--- a/src/main/java/com/prgrms/be02slack/common/configuration/security/JwtConfig.java
+++ b/src/main/java/com/prgrms/be02slack/common/configuration/security/JwtConfig.java
@@ -1,0 +1,27 @@
+package com.prgrms.be02slack.common.configuration.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtConfig {
+  private String tokenSecret;
+  private long tokenExpirationMsec;
+
+  public String getTokenSecret() {
+    return tokenSecret;
+  }
+
+  public void setTokenSecret(String tokenSecret) {
+    this.tokenSecret = tokenSecret;
+  }
+
+  public long getTokenExpirationMsec() {
+    return tokenExpirationMsec;
+  }
+
+  public void setTokenExpirationMsec(long tokenExpirationMsec) {
+    this.tokenExpirationMsec = tokenExpirationMsec;
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/common/dto/AuthResponse.java
+++ b/src/main/java/com/prgrms/be02slack/common/dto/AuthResponse.java
@@ -1,0 +1,20 @@
+package com.prgrms.be02slack.common.dto;
+
+public class AuthResponse {
+  private String token;
+  private String tokenType = "Bearer";
+
+  protected AuthResponse() {}
+
+  public AuthResponse(String token) {
+    this.token = token;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public String getTokenType() {
+    return tokenType;
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/common/exception/UnverifiedEmailException.java
+++ b/src/main/java/com/prgrms/be02slack/common/exception/UnverifiedEmailException.java
@@ -1,0 +1,10 @@
+package com.prgrms.be02slack.common.exception;
+
+public class UnverifiedEmailException extends RuntimeException {
+  public UnverifiedEmailException() {
+  }
+
+  public UnverifiedEmailException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/email/repository/EmailRepository.java
+++ b/src/main/java/com/prgrms/be02slack/email/repository/EmailRepository.java
@@ -12,4 +12,8 @@ public class EmailRepository {
   public void saveCode(String email, String code) {
     map.put(email, code);
   }
+
+  public String findCodeByEmail(String email) {
+    return map.get(email);
+  }
 }

--- a/src/main/java/com/prgrms/be02slack/email/service/EmailService.java
+++ b/src/main/java/com/prgrms/be02slack/email/service/EmailService.java
@@ -10,8 +10,11 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
+import com.prgrms.be02slack.common.exception.NotFoundException;
+import com.prgrms.be02slack.common.exception.UnverifiedEmailException;
 import com.prgrms.be02slack.email.controller.dto.EmailRequest;
 import com.prgrms.be02slack.email.repository.EmailRepository;
+import com.prgrms.be02slack.member.controller.dto.VerificationRequest;
 
 @Service
 public class EmailService {
@@ -66,5 +69,17 @@ public class EmailService {
       }
     }
     return code.toString();
+  }
+
+  public void verifyCode(VerificationRequest request) {
+    String foundCode = emailRepository.findCodeByEmail(request.getEmail());
+
+    if (foundCode == null) {
+      throw new NotFoundException("Verification Code not found");
+    }
+
+    if (foundCode != request.getVerificationCode()) {
+      throw new UnverifiedEmailException("Incorret Vericiation Code");
+    }
   }
 }

--- a/src/main/java/com/prgrms/be02slack/email/service/EmailService.java
+++ b/src/main/java/com/prgrms/be02slack/email/service/EmailService.java
@@ -78,7 +78,7 @@ public class EmailService {
       throw new NotFoundException("Verification Code not found");
     }
 
-    if (foundCode != request.getVerificationCode()) {
+    if (!foundCode.equals(request.getVerificationCode())) {
       throw new UnverifiedEmailException("Incorret Vericiation Code");
     }
   }

--- a/src/main/java/com/prgrms/be02slack/member/controller/MemberApiController.java
+++ b/src/main/java/com/prgrms/be02slack/member/controller/MemberApiController.java
@@ -1,8 +1,16 @@
 package com.prgrms.be02slack.member.controller;
 
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.prgrms.be02slack.member.controller.dto.VerificationRequest;
+import com.prgrms.be02slack.common.dto.AuthResponse;
 import com.prgrms.be02slack.member.service.MemberService;
 
 @RestController
@@ -13,5 +21,11 @@ public class MemberApiController {
 
   public MemberApiController(MemberService memberService) {
     this.memberService = memberService;
+  }
+
+  @PostMapping("verify")
+  @ResponseStatus(HttpStatus.OK)
+  public AuthResponse verify(@RequestBody @Valid VerificationRequest request) {
+    return memberService.verify(request);
   }
 }

--- a/src/main/java/com/prgrms/be02slack/member/controller/dto/VerificationRequest.java
+++ b/src/main/java/com/prgrms/be02slack/member/controller/dto/VerificationRequest.java
@@ -1,0 +1,27 @@
+package com.prgrms.be02slack.member.controller.dto;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+public class VerificationRequest {
+
+  @Email
+  @NotBlank
+  private final String email;
+
+  @NotBlank
+  private final String verificationCode;
+
+  public VerificationRequest(String email, String verificationCode) {
+    this.email = email;
+    this.verificationCode = verificationCode;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getVerificationCode() {
+    return verificationCode;
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/member/entity/Member.java
+++ b/src/main/java/com/prgrms/be02slack/member/entity/Member.java
@@ -52,6 +52,10 @@ public class Member extends BaseTime {
     this.workspace = builder.workspace;
   }
 
+  public String getEmail() {
+    return email;
+  }
+
   public static class Builder {
 
     private String email;

--- a/src/main/java/com/prgrms/be02slack/member/repository/MemberRepository.java
+++ b/src/main/java/com/prgrms/be02slack/member/repository/MemberRepository.java
@@ -12,4 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   Optional<Member> findByEmailAndWorkspace(String email, Workspace workspace);
 
   Optional<Member> findByNameAndWorkspace(String name, Workspace workspace);
+
+  Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
@@ -59,7 +59,7 @@ public class DefaultMemberService implements MemberService {
 
   @Override
   public AuthResponse verify(VerificationRequest request) {
-    Assert.notNull(request, "request is not null");
+    Assert.notNull(request, "Request must not be null");
 
     emailService.verifyCode(request);
 

--- a/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
@@ -6,8 +6,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
 import com.prgrms.be02slack.common.exception.NotFoundException;
+import com.prgrms.be02slack.email.service.EmailService;
+import com.prgrms.be02slack.member.controller.dto.VerificationRequest;
+import com.prgrms.be02slack.common.dto.AuthResponse;
 import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.member.entity.Role;
 import com.prgrms.be02slack.member.repository.MemberRepository;
+import com.prgrms.be02slack.security.TokenProvider;
+import com.prgrms.be02slack.workspace.entity.Workspace;
 import com.prgrms.be02slack.workspace.service.WorkspaceService;
 
 @Service
@@ -15,13 +21,18 @@ public class DefaultMemberService implements MemberService {
 
   private final MemberRepository memberRepository;
   private final WorkspaceService workspaceService;
+  private final EmailService emailService;
+  private final TokenProvider tokenProvider;
 
   public DefaultMemberService(
       MemberRepository memberRepository,
-      WorkspaceService workspaceService
-  ) {
+      WorkspaceService workspaceService,
+      EmailService emailService,
+      TokenProvider tokenProvider) {
     this.memberRepository = memberRepository;
     this.workspaceService = workspaceService;
+    this.emailService = emailService;
+    this.tokenProvider = tokenProvider;
   }
 
   @Override
@@ -44,5 +55,33 @@ public class DefaultMemberService implements MemberService {
 
     return memberRepository.findByNameAndWorkspace(channelName, workspace)
             .isEmpty();
+  }
+
+  @Override
+  public AuthResponse verify(VerificationRequest request) {
+    Assert.notNull(request, "request is not null");
+
+    emailService.verifyCode(request);
+
+    final String email = request.getEmail();
+    final Member member = memberRepository.findByEmail(email).orElseGet(() -> createMember(email));
+
+    return new AuthResponse(tokenProvider.createToken(member.getEmail()));
+  }
+
+  private Member createMember(String email) {
+    final String[] splitEmail = email.split("@");
+    final String defaultName = splitEmail[0];
+    final Workspace workspace = workspaceService.create();
+
+    final Member member = Member.builder()
+        .email(email)
+        .name(defaultName)
+        .displayName(defaultName)
+        .role(Role.OWNER)
+        .workspace(workspace)
+        .build();
+
+    return memberRepository.save(member);
   }
 }

--- a/src/main/java/com/prgrms/be02slack/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/MemberService.java
@@ -2,9 +2,13 @@ package com.prgrms.be02slack.member.service;
 
 import com.prgrms.be02slack.member.entity.Member;
 
-public interface MemberService {
+import com.prgrms.be02slack.member.controller.dto.VerificationRequest;
+import com.prgrms.be02slack.common.dto.AuthResponse;
 
+public interface MemberService {
   Member findByEmailAndWorkspaceKey(String key, String email);
 
   boolean isDuplicatedMemberName(String encodedWorkspaceId, String channelName);
+
+  AuthResponse verify(VerificationRequest request);
 }

--- a/src/main/java/com/prgrms/be02slack/security/TokenProvider.java
+++ b/src/main/java/com/prgrms/be02slack/security/TokenProvider.java
@@ -1,0 +1,62 @@
+package com.prgrms.be02slack.security;
+
+import java.util.Date;
+
+import org.springframework.stereotype.Service;
+
+import com.prgrms.be02slack.common.configuration.security.JwtConfig;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
+
+@Service
+public class TokenProvider {
+
+  private final JwtConfig jwtConfig;
+
+  public TokenProvider(JwtConfig jwtConfig) {
+    this.jwtConfig = jwtConfig;
+  }
+
+  public String createToken(String email) {
+    Date now = new Date();
+
+    return Jwts.builder()
+        .setSubject(email)
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(now.getTime() + jwtConfig.getTokenExpirationMsec()))
+        .signWith(SignatureAlgorithm.HS512, jwtConfig.getTokenSecret())
+        .compact();
+  }
+
+  public String getEmailFromToken(String token) {
+    Claims claims = Jwts.parser()
+        .setSigningKey(jwtConfig.getTokenSecret())
+        .parseClaimsJws(token)
+        .getBody();
+
+    return claims.getSubject();
+  }
+
+  public boolean validateToken(String authToken) {
+    try {
+      Jwts.parser().setSigningKey(jwtConfig.getTokenSecret()).parseClaimsJws(authToken);
+      return true;
+    } catch (SignatureException ex) {
+      return false;
+    } catch (MalformedJwtException ex) {
+      return false;
+    } catch (ExpiredJwtException ex) {
+      return false;
+    } catch (UnsupportedJwtException ex) {
+      return false;
+    } catch (IllegalArgumentException ex) {
+      return false;
+    }
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,3 +14,6 @@ spring:
     properties:
       hibernate.dialect: org.hibernate.dialect.MySQL5InnoDBDialect
       hibernate.format_sql: true
+jwt:
+  client-secret: EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ
+  expiry-seconds: 1800

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,5 +15,5 @@ spring:
       hibernate.dialect: org.hibernate.dialect.MySQL5InnoDBDialect
       hibernate.format_sql: true
 jwt:
-  client-secret: EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ
-  expiry-seconds: 1800
+  tokenSecret: EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ
+  tokenExpirationMsec: 1800

--- a/src/test/java/com/prgrms/be02slack/email/service/EmailServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/email/service/EmailServiceTest.java
@@ -1,0 +1,80 @@
+package com.prgrms.be02slack.email.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.prgrms.be02slack.common.exception.NotFoundException;
+import com.prgrms.be02slack.common.exception.UnverifiedEmailException;
+import com.prgrms.be02slack.email.repository.EmailRepository;
+import com.prgrms.be02slack.member.controller.dto.VerificationRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class EmailServiceTest {
+
+  @Mock
+  EmailRepository emailRepository;
+
+  @InjectMocks
+  EmailService emailService;
+
+  @Nested
+  @DisplayName("verifyCode 메서드는")
+  class DescribeVerifyCode {
+
+    @Nested
+    @DisplayName("email에 해당하는 verification code가 존재하지 않는 경우")
+    class ContextWithNotExistVerificationCode {
+
+      @Test
+      @DisplayName("NotFound 에러를 발생시킨다")
+      void ItResponseNotFoundException() {
+        //given
+        final VerificationRequest request = new VerificationRequest("test@test.com", "testCode");
+        given(emailRepository.findCodeByEmail(anyString())).willReturn(null);
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> emailService.verifyCode(request));
+      }
+    }
+
+    @Nested
+    @DisplayName("verification code가 일치하지 않은 경우")
+    class ContextWithIncorrectVerificationCode {
+
+      @Test
+      @DisplayName("UnverifiedEmailException 에러를 발생시킨다")
+      void ItResponseUnverifiedEmailException() {
+        //given
+        final VerificationRequest request = new VerificationRequest("test@test.com", "testCode");
+        given(emailRepository.findCodeByEmail(anyString())).willReturn("IncorrectCode");
+
+        //when, then
+        assertThrows(UnverifiedEmailException.class, () -> emailService.verifyCode(request));
+      }
+    }
+
+    @Nested
+    @DisplayName("verification code가 일치하는 경우")
+    class ContextWithCorrectVerificationCode {
+
+      @Test
+      @DisplayName("에러가 발생하지 않는다")
+      void ItResponseNothing() {
+        //given
+        final VerificationRequest request = new VerificationRequest("test@test.com", "testCode");
+        given(emailRepository.findCodeByEmail(anyString())).willReturn("testCode");
+
+        //when, then
+        assertDoesNotThrow(() -> emailService.verifyCode(request));
+      }
+    }
+  }
+}

--- a/src/test/java/com/prgrms/be02slack/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/prgrms/be02slack/member/controller/MemberControllerTest.java
@@ -1,0 +1,184 @@
+package com.prgrms.be02slack.member.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.MockBeans;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.be02slack.common.dto.AuthResponse;
+import com.prgrms.be02slack.member.controller.dto.VerificationRequest;
+import com.prgrms.be02slack.member.service.MemberService;
+
+@WebMvcTest(
+    controllers = MemberApiController.class,
+    excludeAutoConfiguration = SecurityAutoConfiguration.class
+)
+@MockBeans({@MockBean(JpaMetamodelMappingContext.class)})
+@AutoConfigureRestDocs
+public class MemberControllerTest {
+
+  private static final String API_URL = "/api/v1/members";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private MemberService memberService;
+
+  @Nested
+  @DisplayName("verfiy 메서드는")
+  class DescribeVerify {
+
+    private static final String VERIFY_URI = "/verify";
+
+    @Nested
+    @DisplayName("유효하지 않은 email이 전달 되면")
+    class ContextInvalidEmail {
+
+      @ParameterizedTest
+      @ValueSource(strings = {
+          "apple",
+          "Hello.com"
+      })
+      @DisplayName("BadRequest를 반환한다.")
+      void itReturnBadRequest(String email) throws Exception {
+        //given
+        final VerificationRequest requestMap = new VerificationRequest(email, "test");
+        final String requestBody = objectMapper.writeValueAsString(requestMap);
+
+        //when
+        final MockHttpServletRequestBuilder request =
+            RestDocumentationRequestBuilders.post(API_URL + VERIFY_URI)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody);
+
+        final ResultActions response = mockMvc.perform(request);
+
+        //then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("email이 존재하지 않거나 빈 값이면")
+    class ContextWithNullOrEmptyEmail {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\n", "\t", "", ""})
+      @DisplayName("BadRequest를 반환한다.")
+      void ItResponseBadRequest(String email) throws Exception {
+        //given
+        final VerificationRequest requestMap = new VerificationRequest(email, "test");
+        final String requestBody = objectMapper.writeValueAsString(requestMap);
+
+        //when
+        final MockHttpServletRequestBuilder request =
+            RestDocumentationRequestBuilders.post(API_URL + VERIFY_URI)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody);
+
+        final ResultActions response = mockMvc.perform(request);
+
+        //then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("verificationCode가 존재하지 않거나 빈 값이면")
+    class ContextWithNullOrEmptyVerificationCode {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\n", "\t", "", ""})
+      @DisplayName("BadRequest를 반환한다.")
+      void ItResponseBadRequest(String verificationCode) throws Exception {
+        //given
+        final VerificationRequest requestMap =
+            new VerificationRequest("test@test.com", verificationCode);
+        final String requestBody = objectMapper.writeValueAsString(requestMap);
+
+        //when
+        final MockHttpServletRequestBuilder request =
+            RestDocumentationRequestBuilders.post(API_URL + VERIFY_URI)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody);
+
+        final ResultActions response = mockMvc.perform(request);
+
+        //then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("토큰을 전달한다")
+      void ItResponseToken() throws Exception {
+        //given
+        final VerificationRequest requestMap =
+            new VerificationRequest("test@test.com", "test");
+        final String requestBody = objectMapper.writeValueAsString(requestMap);
+        final AuthResponse authResponse = new AuthResponse("testToken");
+        given(memberService.verify(any(VerificationRequest.class))).willReturn(authResponse);
+
+        //when
+        final MockHttpServletRequestBuilder request =
+            RestDocumentationRequestBuilders.post(API_URL + VERIFY_URI)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody);
+
+        final ResultActions response = mockMvc.perform(request);
+
+        //then
+        //verify(memberService).verify(any(VerificationRequest.class));
+        response.andExpect(status().isOk())
+            .andDo(document("Verify email",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("email")
+                        .type(JsonFieldType.STRING)
+                        .description("이메일명"),
+                    fieldWithPath("verificationCode")
+                        .type(JsonFieldType.STRING)
+                        .description("인증 코드")
+                ),
+                responseFields(
+                    fieldWithPath("token").type(JsonFieldType.STRING).description("토큰"),
+                    fieldWithPath("tokenType").type(JsonFieldType.STRING).description("토큰 타입")
+                )));
+      }
+    }
+
+  }
+}

--- a/src/test/java/com/prgrms/be02slack/security/TokenProviderTest.java
+++ b/src/test/java/com/prgrms/be02slack/security/TokenProviderTest.java
@@ -1,0 +1,42 @@
+package com.prgrms.be02slack.security;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.prgrms.be02slack.common.configuration.security.JwtConfig;
+
+import io.jsonwebtoken.Jwts;
+
+@ExtendWith(MockitoExtension.class)
+public class TokenProviderTest {
+
+  @Mock
+  JwtConfig jwtConfig;
+
+  @InjectMocks
+  TokenProvider tokenProvider;
+
+  @Test
+  void createTokenTest() {
+    //given
+    final String email = "test@test.com";
+    given(jwtConfig.getTokenSecret()).willReturn("testTokenSecretKey");
+    given(jwtConfig.getTokenExpirationMsec()).willReturn(1000000L);
+
+    //when, then
+    String createdToken = tokenProvider.createToken(email);
+    String subject = Jwts.parser()
+        .setSigningKey(jwtConfig.getTokenSecret())
+        .parseClaimsJws(createdToken)
+        .getBody()
+        .getSubject();
+
+    assertThat(subject).isEqualTo(email);
+  }
+}


### PR DESCRIPTION
* 이메일 인증 코드를 검증하고, 토큰을 발급해주는 기능입니다. 
* 발급된 토큰은 해당 이메일이 포함된 워크스페이스 목록을 조회하거나 워크스페이스에 입장할 때 사용되는 토큰입니다.
* 흐름은 아래와 같습니다.
1. 인증 코드가 일치하는지 확인
2. 해당 이메일을 가진 멤버가 존재하는지 확인 (해당 이메일로 포함된 워크스페이스가 존재하는지 확인)
3-1. 존재한다면, 토큰 생성
3-2. 존재하지 않는다면, 디폴트 워크스페이스 생성 -> 멤버 생성 -> 토큰 생성 