### PR TITLE
:sparkles: SubscribeInfo 테이블 작성 및 양방향 연관관계 추가

### DIFF
--- a/src/main/java/com/prgrms/be02slack/channel/entity/Channel.java
+++ b/src/main/java/com/prgrms/be02slack/channel/entity/Channel.java
@@ -1,7 +1,7 @@
 package com.prgrms.be02slack.channel.entity;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.prgrms.be02slack.common.entity.BaseTime;
 import com.prgrms.be02slack.member.entity.Member;
@@ -57,7 +57,7 @@ public class Channel extends BaseTime {
   private Member owner;
 
   @OneToMany(mappedBy = "channel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-  private Set<SubscribeInfo> subscribeInfos = new HashSet<>();
+  private List<SubscribeInfo> subscribeInfos = new ArrayList<>();
 
   public Long getId() {
     return id;

--- a/src/main/java/com/prgrms/be02slack/channel/entity/Channel.java
+++ b/src/main/java/com/prgrms/be02slack/channel/entity/Channel.java
@@ -1,9 +1,14 @@
 package com.prgrms.be02slack.channel.entity;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import com.prgrms.be02slack.common.entity.BaseTime;
 import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.subscribeInfo.entity.SubscribeInfo;
 import com.prgrms.be02slack.workspace.entity.Workspace;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -12,6 +17,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
@@ -49,6 +55,9 @@ public class Channel extends BaseTime {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id")
   private Member owner;
+
+  @OneToMany(mappedBy = "channel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  private Set<SubscribeInfo> subscribeInfos = new HashSet<>();
 
   public Long getId() {
     return id;

--- a/src/main/java/com/prgrms/be02slack/member/entity/Member.java
+++ b/src/main/java/com/prgrms/be02slack/member/entity/Member.java
@@ -1,9 +1,7 @@
 package com.prgrms.be02slack.member.entity;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
@@ -51,7 +49,7 @@ public class Member extends BaseTime {
   private Workspace workspace;
 
   @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-  private Set<SubscribeInfo> subscribeInfos = new HashSet<>();
+  private List<SubscribeInfo> subscribeInfos = new ArrayList<>();
 
   protected Member() {}
 

--- a/src/main/java/com/prgrms/be02slack/member/entity/Member.java
+++ b/src/main/java/com/prgrms/be02slack/member/entity/Member.java
@@ -1,5 +1,11 @@
 package com.prgrms.be02slack.member.entity;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -9,10 +15,12 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import com.prgrms.be02slack.subscribeInfo.entity.SubscribeInfo;
 import com.prgrms.be02slack.common.entity.BaseTime;
 import com.prgrms.be02slack.workspace.entity.Workspace;
 
@@ -41,6 +49,9 @@ public class Member extends BaseTime {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "workspace_id")
   private Workspace workspace;
+
+  @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  private Set<SubscribeInfo> subscribeInfos = new HashSet<>();
 
   protected Member() {}
 

--- a/src/main/java/com/prgrms/be02slack/subscribeInfo/entity/SubscribeInfo.java
+++ b/src/main/java/com/prgrms/be02slack/subscribeInfo/entity/SubscribeInfo.java
@@ -1,0 +1,28 @@
+package com.prgrms.be02slack.subscribeInfo.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.prgrms.be02slack.channel.entity.Channel;
+import com.prgrms.be02slack.member.entity.Member;
+
+@Entity
+public class SubscribeInfo {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "channel_id")
+  private Channel channel;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
+}


### PR DESCRIPTION
## 🗽구현내용

SubscribeInfo 테이블 작성입니다.

멤버와 채널의 다대다 관계를 풀기위한 연결테이블이며 추후 채널을 통해 구독하는 멤버들을 조회, 멤버를 통해 구독하고 있는 채널을 조회 하는 API를 구현하려고 합니다.

## PR 중점 

- 순서는 중요하지 않을것 같아 O(1) 의 set 자료구조를 사용하였습니다.
- 인텔리제이에서 `private Set<SubscribeInfo> subscribeInfos = new HashSet<>();` 코드에 final 을 붙일것을 권장을 하는데, final  키워드를 붙이게 되면 어떤 영향이 있나요?
- 패키지 구조는 SubscribeInfo 패키지를 따로 만들었습니다. 해당 패키지에 구독정보를 조회하는 api가 있는 controller를 설계할 것같습니다.