### PR TITLE
:sparkles: XS2-104 errorhandler, logger 추가

### DIFF
--- a/src/main/java/com/prgrms/be02slack/common/exception/ExceptionController.java
+++ b/src/main/java/com/prgrms/be02slack/common/exception/ExceptionController.java
@@ -2,19 +2,62 @@ package com.prgrms.be02slack.common.exception;
 
 import javax.validation.ConstraintViolationException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingPathVariableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @ControllerAdvice
 public class ExceptionController {
+
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public void handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    logger.warn("MethodArgumentNotValidException : ", e);
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public void handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+    logger.warn("MethodArgumentTypeMismatchException : ", e);
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public void handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+    logger.warn("HttpMessageNotReadableException : ", e);
+  }
 
   @ExceptionHandler(value = {
       ConstraintViolationException.class,
       MissingPathVariableException.class})
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public void handleConstraintViolationException(Exception e) {
+    logger.warn("PathVariable is blank : ", e);
+  }
+
+  @ExceptionHandler(NotFoundException.class)
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  public void handleNotFoundException(NotFoundException e) {
+    logger.warn("NotFoundException : ", e);
+  }
+
+  @ExceptionHandler(RuntimeException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public void handleRuntimeException(RuntimeException e) {
+    logger.error("RuntimeException : ", e);
+  }
+
+  @ExceptionHandler(Exception.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public void handleException(Exception e) {
+    logger.error("Exception :", e);
   }
 }

--- a/src/main/java/com/prgrms/be02slack/common/exception/ExceptionController.java
+++ b/src/main/java/com/prgrms/be02slack/common/exception/ExceptionController.java
@@ -19,25 +19,28 @@ public class ExceptionController {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
+  @Order(1)
   @ExceptionHandler(MethodArgumentNotValidException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-
   public void handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
     logger.warn("MethodArgumentNotValidException : ", e);
   }
 
+  @Order(2)
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public void handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
     logger.warn("MethodArgumentTypeMismatchException : ", e);
   }
 
+  @Order(3)
   @ExceptionHandler(HttpMessageNotReadableException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public void handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
     logger.warn("HttpMessageNotReadableException : ", e);
   }
 
+  @Order(4)
   @ExceptionHandler(value = {
       ConstraintViolationException.class,
       MissingPathVariableException.class})
@@ -46,18 +49,21 @@ public class ExceptionController {
     logger.warn("PathVariable is blank : ", e);
   }
 
+  @Order(5)
   @ExceptionHandler(NotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public void handleNotFoundException(NotFoundException e) {
     logger.warn("NotFoundException : ", e);
   }
 
+  @Order(6)
   @ExceptionHandler(RuntimeException.class)
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   public void handleRuntimeException(RuntimeException e) {
     logger.error("RuntimeException : ", e);
   }
 
+  @Order(7)
   @ExceptionHandler(Exception.class)
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   public void handleException(Exception e) {

--- a/src/main/java/com/prgrms/be02slack/common/exception/ExceptionController.java
+++ b/src/main/java/com/prgrms/be02slack/common/exception/ExceptionController.java
@@ -18,53 +18,55 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 public class ExceptionController {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+  @Order(1)
   @ExceptionHandler(MethodArgumentNotValidException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  @Order(1)
+
   public void handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
     logger.warn("MethodArgumentNotValidException : ", e);
   }
 
+  @Order(2)
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  @Order(2)
   public void handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
     logger.warn("MethodArgumentTypeMismatchException : ", e);
   }
 
+  @Order(3)
   @ExceptionHandler(HttpMessageNotReadableException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  @Order(3)
   public void handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
     logger.warn("HttpMessageNotReadableException : ", e);
   }
 
+  @Order(4)
   @ExceptionHandler(value = {
       ConstraintViolationException.class,
       MissingPathVariableException.class})
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  @Order(4)
   public void handleConstraintViolationException(Exception e) {
     logger.warn("PathVariable is blank : ", e);
   }
 
+  @Order(5)
   @ExceptionHandler(NotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
-  @Order(5)
   public void handleNotFoundException(NotFoundException e) {
     logger.warn("NotFoundException : ", e);
   }
 
+  @Order(6)
   @ExceptionHandler(RuntimeException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  @Order(6)
   public void handleRuntimeException(RuntimeException e) {
     logger.error("RuntimeException : ", e);
   }
 
+  @Order(7)
   @ExceptionHandler(Exception.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  @Order(7)
   public void handleException(Exception e) {
     logger.error("Exception :", e);
   }

--- a/src/main/java/com/prgrms/be02slack/common/exception/ExceptionController.java
+++ b/src/main/java/com/prgrms/be02slack/common/exception/ExceptionController.java
@@ -19,7 +19,6 @@ public class ExceptionController {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-  @Order(1)
   @ExceptionHandler(MethodArgumentNotValidException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
 
@@ -27,21 +26,18 @@ public class ExceptionController {
     logger.warn("MethodArgumentNotValidException : ", e);
   }
 
-  @Order(2)
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public void handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
     logger.warn("MethodArgumentTypeMismatchException : ", e);
   }
 
-  @Order(3)
   @ExceptionHandler(HttpMessageNotReadableException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public void handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
     logger.warn("HttpMessageNotReadableException : ", e);
   }
 
-  @Order(4)
   @ExceptionHandler(value = {
       ConstraintViolationException.class,
       MissingPathVariableException.class})
@@ -50,23 +46,20 @@ public class ExceptionController {
     logger.warn("PathVariable is blank : ", e);
   }
 
-  @Order(5)
   @ExceptionHandler(NotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public void handleNotFoundException(NotFoundException e) {
     logger.warn("NotFoundException : ", e);
   }
 
-  @Order(6)
   @ExceptionHandler(RuntimeException.class)
-  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   public void handleRuntimeException(RuntimeException e) {
     logger.error("RuntimeException : ", e);
   }
 
-  @Order(7)
   @ExceptionHandler(Exception.class)
-  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   public void handleException(Exception e) {
     logger.error("Exception :", e);
   }

--- a/src/main/java/com/prgrms/be02slack/common/exception/ExceptionController.java
+++ b/src/main/java/com/prgrms/be02slack/common/exception/ExceptionController.java
@@ -4,6 +4,7 @@ import javax.validation.ConstraintViolationException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -19,18 +20,21 @@ public class ExceptionController {
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
   @ExceptionHandler(MethodArgumentNotValidException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @Order(1)
   public void handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
     logger.warn("MethodArgumentNotValidException : ", e);
   }
 
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @Order(2)
   public void handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
     logger.warn("MethodArgumentTypeMismatchException : ", e);
   }
 
   @ExceptionHandler(HttpMessageNotReadableException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @Order(3)
   public void handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
     logger.warn("HttpMessageNotReadableException : ", e);
   }
@@ -39,24 +43,28 @@ public class ExceptionController {
       ConstraintViolationException.class,
       MissingPathVariableException.class})
   @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @Order(4)
   public void handleConstraintViolationException(Exception e) {
     logger.warn("PathVariable is blank : ", e);
   }
 
   @ExceptionHandler(NotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
+  @Order(5)
   public void handleNotFoundException(NotFoundException e) {
     logger.warn("NotFoundException : ", e);
   }
 
   @ExceptionHandler(RuntimeException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @Order(6)
   public void handleRuntimeException(RuntimeException e) {
     logger.error("RuntimeException : ", e);
   }
 
   @ExceptionHandler(Exception.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @Order(7)
   public void handleException(Exception e) {
     logger.error("Exception :", e);
   }


### PR DESCRIPTION
ExceptionController에 ExceptionHandler를 추가했습니다.
logger로 StackTrace를 남기도록 했습니다.

Logger Level : warn
---
1. ```MethodArgumentNotValidException``` : 요청 데이터의 dto Validation 예외    
2.```MethodArgumentTypeMismatchException``` : 요청 데이터와 dto간 데이터 타입 불일치   
3.```HttpMessageNotReadableException ``` :  요청 body가 json 형식이 아닐경우    
4.```NotFoundException ``` :  요청에대한 리소스를 찾을 수 없는 경우

Logger Level : error
---
마지막 RuntimeException과 Exception은 예상치 못한 예외 발생을 막기위해 추가했습니다.

