### PR TITLE
XS2-155 구독 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/be02slack/channel/entity/Channel.java
+++ b/src/main/java/com/prgrms/be02slack/channel/entity/Channel.java
@@ -63,8 +63,8 @@ public class Channel extends BaseTime {
     return id;
   }
 
-  public List<SubscribeInfo> getSubscribeInfos() {
-    return subscribeInfos;
+  public void addSubscribeInfo(SubscribeInfo subscribeInfo) {
+    subscribeInfos.add(subscribeInfo);
   }
 
   public static Builder builder() {

--- a/src/main/java/com/prgrms/be02slack/channel/entity/Channel.java
+++ b/src/main/java/com/prgrms/be02slack/channel/entity/Channel.java
@@ -63,6 +63,10 @@ public class Channel extends BaseTime {
     return id;
   }
 
+  public List<SubscribeInfo> getSubscribeInfos() {
+    return subscribeInfos;
+  }
+
   public static Builder builder() {
     return new Builder();
   }

--- a/src/main/java/com/prgrms/be02slack/member/entity/Member.java
+++ b/src/main/java/com/prgrms/be02slack/member/entity/Member.java
@@ -69,8 +69,8 @@ public class Member extends BaseTime {
     return role.name();
   }
 
-  public List<SubscribeInfo> getSubscribeInfos() {
-    return subscribeInfos;
+  public void addSubscribeInfo(SubscribeInfo subscribeInfo) {
+    subscribeInfos.add(subscribeInfo);
   }
 
   public static class Builder {

--- a/src/main/java/com/prgrms/be02slack/member/entity/Member.java
+++ b/src/main/java/com/prgrms/be02slack/member/entity/Member.java
@@ -69,6 +69,10 @@ public class Member extends BaseTime {
     return role.name();
   }
 
+  public List<SubscribeInfo> getSubscribeInfos() {
+    return subscribeInfos;
+  }
+
   public static class Builder {
 
     private String email;

--- a/src/main/java/com/prgrms/be02slack/subscribeInfo/entity/SubscribeInfo.java
+++ b/src/main/java/com/prgrms/be02slack/subscribeInfo/entity/SubscribeInfo.java
@@ -8,6 +8,8 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
+import org.springframework.util.Assert;
+
 import com.prgrms.be02slack.channel.entity.Channel;
 import com.prgrms.be02slack.member.entity.Member;
 
@@ -25,4 +27,39 @@ public class SubscribeInfo {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id")
   private Member member;
+
+  protected SubscribeInfo() {/*no-op*/}
+
+  private SubscribeInfo(Channel channel, Member member) {
+    Assert.notNull(channel, "Channel must be provided");
+    Assert.notNull(member, "Member must be provided");
+
+    this.channel = channel;
+    this.member = member;
+  }
+
+  public static SubscribeInfo subscribe(Channel channel, Member member) {
+    Assert.notNull(channel, "Channel must be provided");
+    Assert.notNull(member, "Member must be provided");
+
+    final var subscribeInfo = new SubscribeInfo(channel, member);
+
+    subscribeInfo.getChannel()
+        .getSubscribeInfos()
+        .add(subscribeInfo);
+
+    subscribeInfo.getMember()
+        .getSubscribeInfos()
+        .add(subscribeInfo);
+
+    return subscribeInfo;
+  }
+
+  public Channel getChannel() {
+    return channel;
+  }
+
+  public Member getMember() {
+    return member;
+  }
 }

--- a/src/main/java/com/prgrms/be02slack/subscribeInfo/entity/SubscribeInfo.java
+++ b/src/main/java/com/prgrms/be02slack/subscribeInfo/entity/SubscribeInfo.java
@@ -43,14 +43,8 @@ public class SubscribeInfo {
     Assert.notNull(member, "Member must be provided");
 
     final var subscribeInfo = new SubscribeInfo(channel, member);
-
-    subscribeInfo.getChannel()
-        .getSubscribeInfos()
-        .add(subscribeInfo);
-
-    subscribeInfo.getMember()
-        .getSubscribeInfos()
-        .add(subscribeInfo);
+    channel.addSubscribeInfo(subscribeInfo);
+    member.addSubscribeInfo(subscribeInfo);
 
     return subscribeInfo;
   }

--- a/src/main/java/com/prgrms/be02slack/subscribeInfo/repository/SubscribeInfoRepository.java
+++ b/src/main/java/com/prgrms/be02slack/subscribeInfo/repository/SubscribeInfoRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.be02slack.subscribeInfo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.prgrms.be02slack.subscribeInfo.entity.SubscribeInfo;
+
+public interface SubscribeInfoRepository extends JpaRepository<SubscribeInfo, Long> {
+}

--- a/src/main/java/com/prgrms/be02slack/subscribeInfo/service/DefaultSubscribeInfoService.java
+++ b/src/main/java/com/prgrms/be02slack/subscribeInfo/service/DefaultSubscribeInfoService.java
@@ -1,0 +1,30 @@
+package com.prgrms.be02slack.subscribeInfo.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import com.prgrms.be02slack.channel.entity.Channel;
+import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.subscribeInfo.entity.SubscribeInfo;
+import com.prgrms.be02slack.subscribeInfo.repository.SubscribeInfoRepository;
+
+@Service
+@Transactional
+public class DefaultSubscribeInfoService implements SubscribeInfoService {
+
+  private final SubscribeInfoRepository subscribeInfoRepository;
+
+  public DefaultSubscribeInfoService(SubscribeInfoRepository subscribeInfoRepository) {
+    this.subscribeInfoRepository = subscribeInfoRepository;
+  }
+
+  @Override
+  public void subscribe(Channel channel, Member member) {
+    Assert.notNull(channel, "Channel must be provided");
+    Assert.notNull(member, "Member must be provided");
+
+    final var subscribeInfo = SubscribeInfo.subscribe(channel, member);
+    subscribeInfoRepository.save(subscribeInfo);
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/subscribeInfo/service/SubscribeInfoService.java
+++ b/src/main/java/com/prgrms/be02slack/subscribeInfo/service/SubscribeInfoService.java
@@ -1,0 +1,9 @@
+package com.prgrms.be02slack.subscribeInfo.service;
+
+import com.prgrms.be02slack.channel.entity.Channel;
+import com.prgrms.be02slack.member.entity.Member;
+
+public interface SubscribeInfoService {
+
+  void subscribe(Channel channel, Member member);
+}

--- a/src/test/java/com/prgrms/be02slack/subscribeInfo/service/DefaultSubscribeInfoServiceIntegrationTest.java
+++ b/src/test/java/com/prgrms/be02slack/subscribeInfo/service/DefaultSubscribeInfoServiceIntegrationTest.java
@@ -1,0 +1,58 @@
+package com.prgrms.be02slack.subscribeInfo.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.prgrms.be02slack.channel.entity.Channel;
+import com.prgrms.be02slack.channel.repository.ChannelRepository;
+import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.member.entity.Role;
+import com.prgrms.be02slack.member.repository.MemberRepository;
+import com.prgrms.be02slack.workspace.entity.Workspace;
+import com.prgrms.be02slack.workspace.repository.WorkspaceRepository;
+
+@SpringBootTest
+public class DefaultSubscribeInfoServiceIntegrationTest {
+
+  @Autowired
+  private ChannelRepository channelRepository;
+
+  @Autowired
+  private WorkspaceRepository workspaceRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private SubscribeInfoService subscribeInfoService;
+
+  @Test
+  public void queryTest() {
+    final var workspace = Workspace.createDefaultWorkspace();
+    workspaceRepository.save(workspace);
+
+    final var member = Member.builder()
+        .email("test@naver.com")
+        .name("test")
+        .displayName("test")
+        .role(Role.ROLE_OWNER)
+        .workspace(workspace)
+        .build();
+
+    memberRepository.save(member);
+
+    final var channel = Channel.builder()
+        .workspace(workspace)
+        .description("test")
+        .name("test")
+        .isPrivate(true)
+        .owner(member)
+        .build();
+
+    channelRepository.save(channel);
+
+    //when
+    subscribeInfoService.subscribe(channel, member);
+  }
+}

--- a/src/test/java/com/prgrms/be02slack/subscribeInfo/service/DefaultSubscribeInfoServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/subscribeInfo/service/DefaultSubscribeInfoServiceTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -11,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.prgrms.be02slack.channel.entity.Channel;
 import com.prgrms.be02slack.member.entity.Member;
@@ -115,8 +118,16 @@ class DefaultSubscribeInfoServiceTest {
         subscribeInfoService.subscribe(channel, member);
 
         //then
-        assertEquals(channel.getSubscribeInfos().size(), 1);
-        assertEquals(member.getSubscribeInfos().size(), 1);
+        final var channelSubscribeInfos =
+            (List<SubscribeInfo>) ReflectionTestUtils.getField(channel, "subscribeInfos");
+        final var memberSubscribeInfos =
+            (List<SubscribeInfo>) ReflectionTestUtils.getField(member, "subscribeInfos");
+
+        assert channelSubscribeInfos != null;
+        assert memberSubscribeInfos != null;
+
+        assertEquals(channelSubscribeInfos.size(), 1);
+        assertEquals(memberSubscribeInfos.size(), 1);
         verify(subscribeInfoRepository).save(any(SubscribeInfo.class));
       }
     }

--- a/src/test/java/com/prgrms/be02slack/subscribeInfo/service/DefaultSubscribeInfoServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/subscribeInfo/service/DefaultSubscribeInfoServiceTest.java
@@ -1,0 +1,124 @@
+package com.prgrms.be02slack.subscribeInfo.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.prgrms.be02slack.channel.entity.Channel;
+import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.member.entity.Role;
+import com.prgrms.be02slack.subscribeInfo.entity.SubscribeInfo;
+import com.prgrms.be02slack.subscribeInfo.repository.SubscribeInfoRepository;
+import com.prgrms.be02slack.workspace.entity.Workspace;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultSubscribeInfoServiceTest {
+
+  @Mock
+  private SubscribeInfoRepository subscribeInfoRepository;
+
+  @InjectMocks
+  private DefaultSubscribeInfoService subscribeInfoService;
+
+  @Nested
+  @DisplayName("Subscribe 메서드는")
+  class DescribeSubscribe {
+
+    @Nested
+    @DisplayName("Channel 값이 null 이면")
+    class ContextWithChannelNull {
+
+      @Test
+      @DisplayName("IllegalArgumentException 에러를 발생시킨다")
+      void ItThrowsIllegalArgumentException() {
+        //given
+        final var workspace = Workspace.createDefaultWorkspace();
+        final var member = Member.builder()
+            .email("test@naver.com")
+            .name("test")
+            .displayName("test")
+            .role(Role.ROLE_USER)
+            .workspace(workspace)
+            .build();
+
+        //when, then
+        assertThrows(IllegalArgumentException.class,
+            () -> subscribeInfoService.subscribe(null, member));
+      }
+    }
+
+    @Nested
+    @DisplayName("Member 값이 null 이면")
+    class ContextWithMemberNull {
+
+      @Test
+      @DisplayName("IllegalArgumentException 에러를 발생시킨다")
+      void ItThrowsIllegalArgumentException() {
+        //given
+        final var workspace = Workspace.createDefaultWorkspace();
+        final var owner = Member.builder()
+            .email("test@naver.com")
+            .name("test")
+            .displayName("test")
+            .role(Role.ROLE_OWNER)
+            .workspace(workspace)
+            .build();
+
+        final var channel = Channel.builder()
+            .workspace(workspace)
+            .description("test")
+            .name("test")
+            .isPrivate(true)
+            .owner(owner)
+            .build();
+
+        //when, then
+        assertThrows(IllegalArgumentException.class,
+            () -> subscribeInfoService.subscribe(channel, null));
+      }
+    }
+
+    @Nested
+    @DisplayName("모든 값이 전달되면")
+    class ContextWithNotNull {
+
+      @Test
+      @DisplayName("SubscribeInfoRepository 의 save 메서드를 호출한다")
+      void ItCallSaveAtSubscribeInfoRepository() {
+        //given
+        final var workspace = Workspace.createDefaultWorkspace();
+        final var member = Member.builder()
+            .email("test@naver.com")
+            .name("test")
+            .displayName("test")
+            .role(Role.ROLE_OWNER)
+            .workspace(workspace)
+            .build();
+
+        final var channel = Channel.builder()
+            .workspace(workspace)
+            .description("test")
+            .name("test")
+            .isPrivate(true)
+            .owner(member)
+            .build();
+
+        //when
+        subscribeInfoService.subscribe(channel, member);
+
+        //then
+        assertEquals(channel.getSubscribeInfos().size(), 1);
+        assertEquals(member.getSubscribeInfos().size(), 1);
+        verify(subscribeInfoRepository).save(any(SubscribeInfo.class));
+      }
+    }
+  }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -14,3 +14,4 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
         format_sql: true
+    show-sql: true


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

### 기능 구현
- SubscribeInfoService의 subscribe 메서드는 Member와 Channel 을 전달받아 구독하고 있는 채널의 정보를 저장하는 subscribeInfo 엔티티를  subscribe라는 팩토리 메서드를 통해 생성하고 저장합니다.

```java
  @Override
  public void subscribe(Channel channel, Member member) {
    Assert.notNull(channel, "Channel must be provided");
    Assert.notNull(member, "Member must be provided");

    final var subscribeInfo = SubscribeInfo.subscribe(channel, member);
    subscribeInfoRepository.save(subscribeInfo);
  }
```

### 연관관계

멤버가 어떤채널들을 구독하고있는지 조회하는 경우, 채널에 어떤 멤버들이 있는지 조회하는경우 두 경우를 고려하여 양방향 연관관계를 맺게 하였습니다. 

### 테스트 설정관련

format_sql: true 은 되어있는데 show_sql 부분이 없어서 추가했습니다.

### 쿼리 테스트 결과

추가적으로 db 통합테스트를 진행했습니다.

```
    insert 
    into
        subscribe_info
        (id, channel_id, member_id) 
    values
        (default, ?, ?)
```




