### PR TITLE
XS2-65: 멤버 JWT 토큰 발급 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.6.8'
-    testImplementation 'org.springframework.security:spring-security-test:5.7.1'
+    testImplementation 'org.springframework.security:spring-security-test:5.6.1'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:2.0.6.RELEASE'
 }
 

--- a/src/main/java/com/prgrms/be02slack/common/configuration/security/SecurityConfig.java
+++ b/src/main/java/com/prgrms/be02slack/common/configuration/security/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
           .authenticationEntryPoint(authenticationEntryPointImpl())
           .and()
         .authorizeRequests()
+          .antMatchers("/api/v1/members/enter").hasAnyRole("GUEST")
           .anyRequest().permitAll()
           .and()
         .addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/prgrms/be02slack/member/controller/MemberApiController.java
+++ b/src/main/java/com/prgrms/be02slack/member/controller/MemberApiController.java
@@ -3,6 +3,8 @@ package com.prgrms.be02slack.member.controller;
 import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,5 +29,13 @@ public class MemberApiController {
   @ResponseStatus(HttpStatus.OK)
   public AuthResponse verify(@RequestBody @Valid VerificationRequest request) {
     return memberService.verify(request);
+  }
+
+  @PostMapping("enter/{encodedWorkspaceId}")
+  @ResponseStatus(HttpStatus.OK)
+  public AuthResponse enterWorkspace(
+      @AuthenticationPrincipal String email,
+      @PathVariable String encodedWorkspaceId) {
+    return memberService.enterWorkspace(email, encodedWorkspaceId);
   }
 }

--- a/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
@@ -66,6 +66,16 @@ public class DefaultMemberService implements MemberService {
     return new AuthResponse(tokenProvider.createLoginToken(member.getEmail()));
   }
 
+  @Override
+  public AuthResponse enterWorkspace(String email, String encodedWorkspaceId) {
+    Assert.isTrue(isNotBlank(email), "email must be provided");
+    Assert.isTrue(isNotBlank(encodedWorkspaceId), "encodedWorkspaceId must be provided");
+
+    final Member member = findByEmailAndWorkspaceKey(email, encodedWorkspaceId);
+
+    return new AuthResponse(tokenProvider.createMemberToken(member.getEmail(), encodedWorkspaceId));
+  }
+
   private Member createMember(String email) {
     final String[] splitEmail = email.split("@");
     final String defaultName = splitEmail[0];

--- a/src/main/java/com/prgrms/be02slack/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/MemberService.java
@@ -11,4 +11,6 @@ public interface MemberService {
   boolean isDuplicateName(Long decodedWorkspaceId, String channelName);
 
   AuthResponse verify(VerificationRequest request);
+
+  AuthResponse enterWorkspace(String email, String encodedWorkspaceId);
 }

--- a/src/test/java/com/prgrms/be02slack/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/prgrms/be02slack/member/controller/MemberControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -13,41 +14,28 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.MockBeans;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.prgrms.be02slack.common.configuration.security.SecurityConfig;
 import com.prgrms.be02slack.common.dto.AuthResponse;
 import com.prgrms.be02slack.member.controller.dto.VerificationRequest;
 import com.prgrms.be02slack.member.service.MemberService;
+import com.prgrms.be02slack.util.ControllerSetUp;
+import com.prgrms.be02slack.util.WithMockCustomLoginUser;
 
-@WebMvcTest(
-    controllers = MemberApiController.class,
-    excludeAutoConfiguration = SecurityAutoConfiguration.class,
-    excludeFilters = {
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
-    })
+@WebMvcTest(controllers = MemberApiController.class)
 @MockBeans({@MockBean(JpaMetamodelMappingContext.class)})
-@AutoConfigureRestDocs
-public class MemberControllerTest {
+public class MemberControllerTest extends ControllerSetUp {
 
   private static final String API_URL = "/api/v1/members";
-
-  @Autowired
-  private MockMvc mockMvc;
 
   @Autowired
   private ObjectMapper objectMapper;
@@ -165,7 +153,6 @@ public class MemberControllerTest {
         final ResultActions response = mockMvc.perform(request);
 
         //then
-        //verify(memberService).verify(any(VerificationRequest.class));
         response.andExpect(status().isOk())
             .andDo(document("Verify email",
                 preprocessRequest(prettyPrint()),
@@ -184,6 +171,52 @@ public class MemberControllerTest {
                 )));
       }
     }
+  }
 
+  @Nested
+  @DisplayName("enterWorkspace 메서드는")
+  @WithMockCustomLoginUser
+  class DescribeEnterWorkspace {
+
+    private static final String ENTER_URI = "/enter/{encodedWorkspaceId}";
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("토큰을 전달한다")
+      void ItResponseToken() throws Exception {
+        final String encodedWorkspaceId = "TESTID";
+        final AuthResponse authResponse = new AuthResponse("testToken");
+        given(memberService.enterWorkspace(anyString(), anyString())).willReturn(authResponse);
+
+        //when
+        final MockHttpServletRequestBuilder request =
+            RestDocumentationRequestBuilders.post(
+                    API_URL + ENTER_URI, encodedWorkspaceId)
+                .contentType(MediaType.APPLICATION_JSON);
+
+        final ResultActions response = mockMvc.perform(request);
+
+        //then
+        response.andExpect(status().isOk())
+            .andDo(document("Enter workspace",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("encodedWorkspaceId")
+                        .description("인코딩된 워크스페이스 id")
+                ),
+                responseFields(
+                    fieldWithPath("token")
+                        .type(JsonFieldType.STRING)
+                        .description("토큰"),
+                    fieldWithPath("tokenType")
+                        .type(JsonFieldType.STRING)
+                        .description("토큰 타입")
+                )));
+      }
+    }
   }
 }

--- a/src/test/java/com/prgrms/be02slack/util/ControllerSetUp.java
+++ b/src/test/java/com/prgrms/be02slack/util/ControllerSetUp.java
@@ -1,0 +1,40 @@
+package com.prgrms.be02slack.util;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import com.prgrms.be02slack.security.DefaultUserDetailsService;
+import com.prgrms.be02slack.security.TokenProvider;
+
+@ExtendWith(RestDocumentationExtension.class)
+public class ControllerSetUp {
+
+  protected MockMvc mockMvc;
+
+  @MockBean
+  private TokenProvider tokenProvider;
+
+  @MockBean
+  private DefaultUserDetailsService defaultUserDetailsService;
+
+  @BeforeEach
+  public void setUp(WebApplicationContext webApplicationContext,
+      RestDocumentationContextProvider restDocumentationContextProvider) {
+    this.mockMvc = MockMvcBuilders
+        .webAppContextSetup(webApplicationContext)
+        .addFilters(new CharacterEncodingFilter("UTF-8", true))
+        .apply(documentationConfiguration(restDocumentationContextProvider))
+        .apply(springSecurity())
+        .build();
+  }
+}

--- a/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginUser.java
+++ b/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginUser.java
@@ -1,0 +1,16 @@
+package com.prgrms.be02slack.util;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomLoginUserSecurityContextFactory.class)
+public @interface WithMockCustomLoginUser {
+
+  String username() default "test@test.com";
+
+  String role() default "GUEST";
+
+}

--- a/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginUserSecurityContextFactory.java
+++ b/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginUserSecurityContextFactory.java
@@ -1,0 +1,29 @@
+package com.prgrms.be02slack.util;
+
+import java.util.Arrays;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockCustomLoginUserSecurityContextFactory implements
+    WithSecurityContextFactory<WithMockCustomLoginUser> {
+
+  @Override
+  public SecurityContext createSecurityContext(WithMockCustomLoginUser annotation) {
+
+    final SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+
+    final UsernamePasswordAuthenticationToken authenticationToken =
+        new UsernamePasswordAuthenticationToken(
+            annotation.username(),
+        "password",
+        Arrays.asList(new SimpleGrantedAuthority(annotation.role()))
+    );
+
+    securityContext.setAuthentication(authenticationToken);
+    return securityContext;
+  }
+}


### PR DESCRIPTION
* Spring Security Test dependency 다운그레이드
  * spring Boot 2.6.x 버전이 spring security test 5.7.x 버전과 호환성이 맞지 않아 SecurityContextHolderFilter 클래스가 로드되지 않아 에러가 발생했습니다. 그래서 spring security test를 5.6.1 버전으로 다운그레이드 했습니다.
  * https://spring.io/blog/2022/04/18/spring-security-5-7-0-rc1-released
* JWT Member Token 발급 구현
  * JWT Login Token을 가지고 `/api/v1/members/{encodedWorkspaceId} `로 접근하면 토큰 검증 후 JWT Member Token을 발급하도록 구현하였습니다.
* Spring Security 가 적용된 Controller 테스트(MemberControllerTest) 구현
  * 우선 멤버 JWT 토큰 발급을 위한 MemberController 테스트만 Spring Security가 적용된 상태로 구현하였습니다.
  * `WithMockCustomLoginUser`애노테이션: JWT Login Token을 가지고 있는 커스텀된 Authentication 인증 정보 애노테이션 생성
    * JWT Member Token을 가지고 있는 커스텀 Authentication 애노테이션도 구현할 예정입니다. 
  * `WithMockCustomLoginUserSecurityContextFactory` 클래스: SecurityContext에 테스트에서 활용할 인증 정보를 넣어줄 때 사용
  * `ControllerSetUp` 클래스: Spring Security Test 설정 정보와 Rest Docs 설정 정보를 담은 클래스
  