### PR TITLE
:recycle: XS2-57 필요없는 member 필드 삭제

### DIFF
--- a/src/main/java/com/prgrms/be02slack/member/entity/Member.java
+++ b/src/main/java/com/prgrms/be02slack/member/entity/Member.java
@@ -37,10 +37,6 @@ public class Member extends BaseTime {
   @Size(min = 1, max = 80)
   private String name;
 
-  @NotNull
-  @Size(min = 1, max = 80)
-  private String displayName;
-
   @Enumerated(EnumType.STRING)
   private Role role;
 
@@ -56,7 +52,6 @@ public class Member extends BaseTime {
   private Member(Builder builder) {
     this.email = builder.email;
     this.name = builder.name;
-    this.displayName = builder.displayName;
     this.role = builder.role;
     this.workspace = builder.workspace;
   }
@@ -73,7 +68,6 @@ public class Member extends BaseTime {
 
     private String email;
     private String name;
-    private String displayName;
     private Role role;
     private Workspace workspace;
 
@@ -84,11 +78,6 @@ public class Member extends BaseTime {
 
     public Builder name(String name) {
       this.name = name;
-      return this;
-    }
-
-    public Builder displayName(String displayName) {
-      this.displayName = displayName;
       return this;
     }
 

--- a/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/DefaultMemberService.java
@@ -74,7 +74,6 @@ public class DefaultMemberService implements MemberService {
     final Member member = Member.builder()
         .email(email)
         .name(defaultName)
-        .displayName(defaultName)
         .role(Role.ROLE_OWNER)
         .workspace(workspace)
         .build();

--- a/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
@@ -116,7 +116,6 @@ class DefaultMemberServiceTest {
         final var savedMember = Member.builder().name("test")
             .workspace(findWorkspace)
             .email(savedEmail)
-            .displayName("test")
             .role(Role.ROLE_USER)
             .build();
 
@@ -250,7 +249,6 @@ class DefaultMemberServiceTest {
         final Member member = Member.builder()
             .email("test@test.com")
             .name("test")
-            .displayName("test")
             .role(Role.ROLE_OWNER)
             .workspace(workspace)
             .build();
@@ -288,7 +286,6 @@ class DefaultMemberServiceTest {
         final Member member = Member.builder()
             .email("test@test.com")
             .name("test")
-            .displayName("test")
             .role(Role.ROLE_OWNER)
             .workspace(workspace)
             .build();


### PR DESCRIPTION
Member 엔티티의 displayName 필드가 현재 저희 개발에서 필요없는 필드로 생각돼서(name 과 겹침) 삭제했습니다!
