### PR TITLE
XS2-91: [멤버 상세 정보 조회 기능] 구현 전 수정 

### DIFF
--- a/src/main/java/com/prgrms/be02slack/common/configuration/security/SecurityConfig.java
+++ b/src/main/java/com/prgrms/be02slack/common/configuration/security/SecurityConfig.java
@@ -20,6 +20,10 @@ import com.prgrms.be02slack.security.TokenProvider;
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
+  private static final String GUEST = "GUEST";
+  private static final String OWNER = "OWNER";
+  private static final String USER = "USER";
+
   private final TokenProvider tokenProvider;
   private final DefaultUserDetailsService customUserDetailsService;
 
@@ -53,7 +57,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
           .authenticationEntryPoint(authenticationEntryPointImpl())
           .and()
         .authorizeRequests()
-          .antMatchers("/api/v1/members/enter").hasAnyRole("GUEST")
+          .antMatchers(HttpMethod.POST, "/api/v1/workspaces/{encodedWorkspaceId}/token")
+            .hasAnyRole(GUEST)
           .anyRequest().permitAll()
           .and()
         .addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/prgrms/be02slack/security/CurrentMember.java
+++ b/src/main/java/com/prgrms/be02slack/security/CurrentMember.java
@@ -1,0 +1,16 @@
+package com.prgrms.be02slack.security;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : member")
+public @interface CurrentMember {
+}

--- a/src/main/java/com/prgrms/be02slack/security/TokenAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/be02slack/security/TokenAuthenticationFilter.java
@@ -46,8 +46,9 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             Collections.singletonList(new SimpleGrantedAuthority(Role.ROLE_GUEST.name()))
         );
       } else {
-        String tokenPayloadStr = email + " " + tokenType;
-        UserDetails userDetails = customUserDetailsService.loadUserByUsername(tokenPayloadStr);
+        final String encodedWorkspaceId = tokenProvider.getEncodedWorkspaceIdFromToken(token);
+        final String tokenPayloadStr = email + " " + encodedWorkspaceId;
+        final UserDetails userDetails = customUserDetailsService.loadUserByUsername(tokenPayloadStr);
         authentication = new UsernamePasswordAuthenticationToken(
             userDetails,
             null,

--- a/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginUser.java
+++ b/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginUser.java
@@ -11,6 +11,6 @@ public @interface WithMockCustomLoginUser {
 
   String username() default "test@test.com";
 
-  String role() default "GUEST";
+  String role() default "ROLE_GUEST";
 
 }


### PR DESCRIPTION
* 멤버 토큰 발급 기능의 URI 시큐리티 설정이 잘못되어 수정하였습니다.
  * TokenAuthenticationFilter : 토큰 payload의 값을 꺼내는 과정이 잘못되어 수정하였습니다.
* `@CurrentMember` : 로그인한 멤버의 정보를 파라미터로 받기 위해 커스텀 애노테이션을 생성하였습니다.

* 로그인한유저가 아니면 Principal에 null이 들어가는 코드인가요?
  * 넵 로그인을 거치지 않은 유저가 접근한다면 null이 들어갑니다. 
* 멤버 상세정보를 조회할때 이 어노테이션을 사용하는건지 궁금합니다 🙇

```
@GetMapping("api/v1/members/{encodedMemberId}")
@ResponseStatus(HttpStatus.OK)
public MemberResponse getOne(
    @CurrentMember Member member,
    @PathVariable String encodedMemberId) {
  return null;
}
```

이런식으로 사용하면 됩니다!(다음 PR에 올라갈 예정) 파라미터에 애노테이션과 Member 클래스 선언해주면 됩니다.

