### PR TITLE
XS2-91 : 멤버 상세 정보 조회 기능

### DIFF
--- a/src/main/java/com/prgrms/be02slack/common/configuration/security/SecurityConfig.java
+++ b/src/main/java/com/prgrms/be02slack/common/configuration/security/SecurityConfig.java
@@ -59,6 +59,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .authorizeRequests()
           .antMatchers(HttpMethod.POST, "/api/v1/workspaces/{encodedWorkspaceId}/token")
             .hasAnyRole(GUEST)
+        .antMatchers(HttpMethod.GET, "/api/v1/members/{encodedMemberId}")
+          .hasAnyRole(USER, OWNER)
           .anyRequest().permitAll()
           .and()
         .addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/prgrms/be02slack/member/controller/MemberApiController.java
+++ b/src/main/java/com/prgrms/be02slack/member/controller/MemberApiController.java
@@ -1,6 +1,7 @@
 package com.prgrms.be02slack.member.controller;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -37,7 +38,7 @@ public class MemberApiController {
   @ResponseStatus(HttpStatus.OK)
   public AuthResponse enterWorkspace(
       @AuthenticationPrincipal String email,
-      @PathVariable String encodedWorkspaceId) {
+      @PathVariable @NotBlank String encodedWorkspaceId) {
     return memberService.enterWorkspace(email, encodedWorkspaceId);
   }
 
@@ -45,7 +46,7 @@ public class MemberApiController {
   @ResponseStatus(HttpStatus.OK)
   public MemberResponse getOne(
       @CurrentMember Member member,
-      @PathVariable String encodedMemberId) {
+      @PathVariable @NotBlank String encodedMemberId) {
     return memberService.getOne(member, encodedMemberId);
   }
 }

--- a/src/main/java/com/prgrms/be02slack/member/controller/MemberApiController.java
+++ b/src/main/java/com/prgrms/be02slack/member/controller/MemberApiController.java
@@ -4,15 +4,19 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.prgrms.be02slack.member.controller.dto.MemberResponse;
 import com.prgrms.be02slack.member.controller.dto.VerificationRequest;
 import com.prgrms.be02slack.common.dto.AuthResponse;
+import com.prgrms.be02slack.member.entity.Member;
 import com.prgrms.be02slack.member.service.MemberService;
+import com.prgrms.be02slack.security.CurrentMember;
 
 @RestController
 public class MemberApiController {
@@ -35,5 +39,13 @@ public class MemberApiController {
       @AuthenticationPrincipal String email,
       @PathVariable String encodedWorkspaceId) {
     return memberService.enterWorkspace(email, encodedWorkspaceId);
+  }
+
+  @GetMapping("api/v1/members/{encodedMemberId}")
+  @ResponseStatus(HttpStatus.OK)
+  public MemberResponse getOne(
+      @CurrentMember Member member,
+      @PathVariable String encodedMemberId) {
+    return memberService.getOne(member, encodedMemberId);
   }
 }

--- a/src/main/java/com/prgrms/be02slack/member/controller/dto/MemberResponse.java
+++ b/src/main/java/com/prgrms/be02slack/member/controller/dto/MemberResponse.java
@@ -5,22 +5,22 @@ import com.prgrms.be02slack.member.entity.Role;
 
 public class MemberResponse {
 
-  private final String id;
+  private final String encodedMemberId;
   private final String email;
   private final String name;
   private final String displayName;
   private final Role role;
 
   private MemberResponse(Builder builder) {
-    this.id = builder.id;
+    this.encodedMemberId = builder.encodedMemberId;
     this.email = builder.email;
     this.name = builder.name;
     this.displayName = builder.displayName;
     this.role = builder.role;
   }
 
-  public String getId() {
-    return id;
+  public String getEncodedMemberId() {
+    return encodedMemberId;
   }
 
   public String getEmail() {
@@ -44,14 +44,14 @@ public class MemberResponse {
   }
 
   public static class Builder {
-    private String id;
+    private String encodedMemberId;
     private String email;
     private String name;
     private String displayName;
     private Role role;
 
-    public Builder id(String id) {
-      this.id = id;
+    public Builder encodedMemberId(String encodedMemberId) {
+      this.encodedMemberId = encodedMemberId;
       return this;
     }
 
@@ -82,7 +82,7 @@ public class MemberResponse {
 
   public static MemberResponse from(Member member, String encodedMemberId) {
     return MemberResponse.builder()
-        .id(encodedMemberId)
+        .encodedMemberId(encodedMemberId)
         .email(member.getEmail())
         .name(member.getName())
         .displayName(member.getDisplayName())

--- a/src/main/java/com/prgrms/be02slack/member/controller/dto/MemberResponse.java
+++ b/src/main/java/com/prgrms/be02slack/member/controller/dto/MemberResponse.java
@@ -1,0 +1,92 @@
+package com.prgrms.be02slack.member.controller.dto;
+
+import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.member.entity.Role;
+
+public class MemberResponse {
+
+  private final String id;
+  private final String email;
+  private final String name;
+  private final String displayName;
+  private final Role role;
+
+  private MemberResponse(Builder builder) {
+    this.id = builder.id;
+    this.email = builder.email;
+    this.name = builder.name;
+    this.displayName = builder.displayName;
+    this.role = builder.role;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public Role getRole() {
+    return role;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String id;
+    private String email;
+    private String name;
+    private String displayName;
+    private Role role;
+
+    public Builder id(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder email(String email) {
+      this.email = email;
+      return this;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder displayName(String displayName) {
+      this.displayName = displayName;
+      return this;
+    }
+
+    public Builder role(Role role) {
+      this.role = role;
+      return this;
+    }
+
+    public MemberResponse build() {
+      return new MemberResponse(this);
+    }
+  }
+
+  public static MemberResponse from(Member member, String encodedMemberId) {
+    return MemberResponse.builder()
+        .id(encodedMemberId)
+        .email(member.getEmail())
+        .name(member.getName())
+        .displayName(member.getDisplayName())
+        .role(member.getRole())
+        .build();
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/member/entity/Member.java
+++ b/src/main/java/com/prgrms/be02slack/member/entity/Member.java
@@ -65,8 +65,24 @@ public class Member extends BaseTime {
     return email;
   }
 
+  public String getName() {
+    return name;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public Role getRole() {
+    return role;
+  }
+
   public String getRoleName() {
     return role.name();
+  }
+
+  public Workspace getWorkspace() {
+    return workspace;
   }
 
   public void addSubscribeInfo(SubscribeInfo subscribeInfo) {

--- a/src/main/java/com/prgrms/be02slack/member/repository/MemberRepository.java
+++ b/src/main/java/com/prgrms/be02slack/member/repository/MemberRepository.java
@@ -18,4 +18,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   boolean existsByEmailAndWorkspace_Id(String email, Long workspaceId);
 
   Optional<Member> findByEmail(String email);
+
+  Optional<Member> findByIdAndWorkspace_id(Long id, Long workspaceId);
 }

--- a/src/main/java/com/prgrms/be02slack/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/be02slack/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.prgrms.be02slack.member.service;
 
+import com.prgrms.be02slack.member.controller.dto.MemberResponse;
 import com.prgrms.be02slack.member.entity.Member;
 
 import com.prgrms.be02slack.member.controller.dto.VerificationRequest;
@@ -22,4 +23,6 @@ public interface MemberService {
   boolean isExistsByNameAndWorkspaceKey(String name, String key);
 
   Member save(String name, String email, Role role, String workspaceKey, String displayName);
+
+  MemberResponse getOne(Member member, String encodedMemberId);
 }

--- a/src/test/java/com/prgrms/be02slack/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/prgrms/be02slack/member/controller/MemberControllerTest.java
@@ -228,7 +228,7 @@ public class MemberControllerTest extends ControllerSetUp {
   @WithMockCustomLoginMember
   class DescribeGetOne {
 
-    private static final String GET_ONE_URL = "/api/v1/members/{encodedMemberId}";
+    private static final String GET_ONE_URI = "/api/v1/members/{encodedMemberId}";
 
     @Nested
     @DisplayName("유효한 값이 전달되면")
@@ -239,8 +239,8 @@ public class MemberControllerTest extends ControllerSetUp {
       void ItResponseMemberInfo() throws Exception {
         //given
         final String encodedMemberId = "TESTID";
-        MemberResponse memberResponse = MemberResponse.builder()
-            .id("TESTID")
+        final MemberResponse memberResponse = MemberResponse.builder()
+            .encodedMemberId("TESTID")
             .email("test@test.com")
             .name("test")
             .displayName("test")
@@ -250,14 +250,14 @@ public class MemberControllerTest extends ControllerSetUp {
 
         //when
         final MockHttpServletRequestBuilder request =
-            RestDocumentationRequestBuilders.get(GET_ONE_URL, encodedMemberId);
+            RestDocumentationRequestBuilders.get(GET_ONE_URI, encodedMemberId);
 
         final ResultActions response = mockMvc.perform(request);
 
         //then
         verify(memberService).getOne(any(Member.class), anyString());
         response.andExpect(status().isOk())
-            .andExpect(jsonPath("id").value(memberResponse.getId()))
+            .andExpect(jsonPath("encodedMemberId").value(memberResponse.getEncodedMemberId()))
             .andExpect(jsonPath("email").value(memberResponse.getEmail()))
             .andExpect(jsonPath("name").value(memberResponse.getName()))
             .andExpect(jsonPath("displayName").value(memberResponse.getDisplayName()))
@@ -269,7 +269,7 @@ public class MemberControllerTest extends ControllerSetUp {
                     parameterWithName("encodedMemberId").description("Encoded Member Id")
                 ),
                 responseFields(
-                    fieldWithPath("id").type(JsonFieldType.STRING).description("인코딩된 멤버 id"),
+                    fieldWithPath("encodedMemberId").type(JsonFieldType.STRING).description("인코딩된 멤버 id"),
                     fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                     fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
                     fieldWithPath("displayName").type(JsonFieldType.STRING).description("보여지는 이름"),

--- a/src/test/java/com/prgrms/be02slack/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/prgrms/be02slack/member/controller/MemberControllerTest.java
@@ -26,9 +26,13 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.be02slack.common.dto.AuthResponse;
+import com.prgrms.be02slack.member.controller.dto.MemberResponse;
 import com.prgrms.be02slack.member.controller.dto.VerificationRequest;
+import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.member.entity.Role;
 import com.prgrms.be02slack.member.service.MemberService;
 import com.prgrms.be02slack.util.ControllerSetUp;
+import com.prgrms.be02slack.util.WithMockCustomLoginMember;
 import com.prgrms.be02slack.util.WithMockCustomLoginUser;
 
 @WebMvcTest(controllers = MemberApiController.class)
@@ -215,6 +219,63 @@ public class MemberControllerTest extends ControllerSetUp {
                         .type(JsonFieldType.STRING)
                         .description("토큰 타입")
                 )));
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("getOne 메서드는")
+  @WithMockCustomLoginMember
+  class DescribeGetOne {
+
+    private static final String GET_ONE_URL = "/api/v1/members/{encodedMemberId}";
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("멤버 정보를 전달한다")
+      void ItResponseMemberInfo() throws Exception {
+        //given
+        final String encodedMemberId = "TESTID";
+        MemberResponse memberResponse = MemberResponse.builder()
+            .id("TESTID")
+            .email("test@test.com")
+            .name("test")
+            .displayName("test")
+            .role(Role.ROLE_USER)
+            .build();
+        given(memberService.getOne(any(Member.class), anyString())).willReturn(memberResponse);
+
+        //when
+        final MockHttpServletRequestBuilder request =
+            RestDocumentationRequestBuilders.get(GET_ONE_URL, encodedMemberId);
+
+        final ResultActions response = mockMvc.perform(request);
+
+        //then
+        verify(memberService).getOne(any(Member.class), anyString());
+        response.andExpect(status().isOk())
+            .andExpect(jsonPath("id").value(memberResponse.getId()))
+            .andExpect(jsonPath("email").value(memberResponse.getEmail()))
+            .andExpect(jsonPath("name").value(memberResponse.getName()))
+            .andExpect(jsonPath("displayName").value(memberResponse.getDisplayName()))
+            .andExpect(jsonPath("role").value(memberResponse.getRole().name()))
+            .andDo(document("Get Member Info",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("encodedMemberId").description("Encoded Member Id")
+                ),
+                responseFields(
+                    fieldWithPath("id").type(JsonFieldType.STRING).description("인코딩된 멤버 id"),
+                    fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                    fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
+                    fieldWithPath("displayName").type(JsonFieldType.STRING).description("보여지는 이름"),
+                    fieldWithPath("role").type(JsonFieldType.STRING).description("워크스페이스 내 역할")
+                )
+            ));
       }
     }
   }

--- a/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
@@ -734,7 +734,7 @@ class DefaultMemberServiceTest {
         ReflectionTestUtils.setField(member, "workspace", workspace);
         final String encodedMemberId = "TESTID";
         final MemberResponse memberResponse = MemberResponse.builder()
-            .id("TESTID")
+            .encodedMemberId("TESTID")
             .email("test@test.com")
             .name("test")
             .displayName("test")

--- a/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.prgrms.be02slack.common.exception.NotFoundException;
 import com.prgrms.be02slack.common.util.IdEncoder;
 import com.prgrms.be02slack.email.service.EmailService;
+import com.prgrms.be02slack.member.controller.dto.MemberResponse;
 import com.prgrms.be02slack.member.controller.dto.VerificationRequest;
 import com.prgrms.be02slack.common.dto.AuthResponse;
 import com.prgrms.be02slack.member.entity.Member;
@@ -637,6 +638,116 @@ class DefaultMemberServiceTest {
 
         //then
         assertThat(isExists).isFalse();
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("getOne 메서드는")
+  class DescribeGetOne {
+
+    @Nested
+    @DisplayName("member에 null 값이 전달되면")
+    class ContextWithMemberNull {
+
+      @Test
+      @DisplayName("IllegalArgumentException을 반환한다")
+      void ItResponseIllegalArgumentException() {
+        String encodedMemberId = "TESTID";
+        assertThrows(IllegalArgumentException.class, () ->
+            memberService.getOne(null, encodedMemberId));
+      }
+    }
+
+    @Nested
+    @DisplayName("encodedMemberId가 비어있는 인자를 받으면")
+    class ContextWithEncodedMemberIdNullAndEmptySource {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\t", "\n"})
+      @DisplayName("IllegalArgumentException을 반환한다")
+      void ItThrowIllegalArgumentException(String encodedMemberId) {
+        //given
+        final Workspace workspace = Workspace.createDefaultWorkspace();
+        ReflectionTestUtils.setField(workspace, "id", 1L);
+        final Member member = Member.builder()
+            .email("test@test.com")
+            .name("test")
+            .displayName("test")
+            .role(Role.ROLE_USER)
+            .build();
+        ReflectionTestUtils.setField(member, "id", 1L);
+        ReflectionTestUtils.setField(member, "workspace", workspace);
+
+        //when, then
+        assertThrows(IllegalArgumentException.class, () ->
+            memberService.getOne(member, encodedMemberId));
+      }
+    }
+
+    @Nested
+    @DisplayName("해당 멤버 id와 워크스페이스 id을 가진 멤버가 존재하지 않은 경우")
+    class ContextWithNotExistedMember {
+
+      @Test
+      @DisplayName("NotFoundException을 반환한다")
+      void ItResponseNotFoundException() {
+        //given
+        final Workspace workspace = Workspace.createDefaultWorkspace();
+        ReflectionTestUtils.setField(workspace, "id", 1L);
+        final Member member = Member.builder()
+            .email("test@test.com")
+            .name("test")
+            .displayName("test")
+            .role(Role.ROLE_USER)
+            .build();
+        ReflectionTestUtils.setField(member, "id", 1L);
+        ReflectionTestUtils.setField(member, "workspace", workspace);
+        final String encodedMemberId = "TESTID";
+        given(idEncoder.decode(anyString())).willReturn(1L);
+        given(repository.findByIdAndWorkspace_id(anyLong(), anyLong())).willReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () ->
+            memberService.getOne(member, encodedMemberId));
+      }
+    }
+
+    @Nested
+    @DisplayName("해당 멤버 id와 워크스페이스 id을 가진 멤버가 존재할 경우")
+    class ContextWithExistedMember {
+
+      @Test
+      @DisplayName("멤버 정보를 담은 memberResponse을 반환한다")
+      void ItResponseMemberResponse() {
+        //given
+        final Workspace workspace = Workspace.createDefaultWorkspace();
+        ReflectionTestUtils.setField(workspace, "id", 1L);
+        final Member member = Member.builder()
+            .email("test@test.com")
+            .name("test")
+            .displayName("test")
+            .role(Role.ROLE_USER)
+            .build();
+        ReflectionTestUtils.setField(member, "id", 1L);
+        ReflectionTestUtils.setField(member, "workspace", workspace);
+        final String encodedMemberId = "TESTID";
+        final MemberResponse memberResponse = MemberResponse.builder()
+            .id("TESTID")
+            .email("test@test.com")
+            .name("test")
+            .displayName("test")
+            .role(Role.ROLE_USER)
+            .build();
+        given(idEncoder.decode(anyString())).willReturn(1L);
+        given(repository.findByIdAndWorkspace_id(anyLong(), anyLong())).willReturn(Optional.of(member));
+
+        //when
+        final MemberResponse foundMemberResponse = memberService.getOne(member, encodedMemberId);
+
+        // then
+        assertThat(foundMemberResponse).usingRecursiveComparison().isEqualTo(memberResponse);
       }
     }
   }

--- a/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginMember.java
+++ b/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginMember.java
@@ -1,0 +1,25 @@
+package com.prgrms.be02slack.util;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import com.prgrms.be02slack.member.entity.Role;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomLoginMemberSecurityContextFactory.class)
+public @interface WithMockCustomLoginMember {
+
+  long id() default 1L;
+
+  String email() default "test@test.com";
+
+  String name() default "test";
+
+  String displayName() default "test";
+
+  Role role() default Role.ROLE_USER;
+
+  long workspaceId() default 1L;
+}

--- a/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginMemberSecurityContextFactory.java
+++ b/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginMemberSecurityContextFactory.java
@@ -1,0 +1,45 @@
+package com.prgrms.be02slack.util;
+
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.security.MemberDetails;
+import com.prgrms.be02slack.workspace.entity.Workspace;
+
+public class WithMockCustomLoginMemberSecurityContextFactory implements
+    WithSecurityContextFactory<WithMockCustomLoginMember> {
+
+  @Override
+  public SecurityContext createSecurityContext(WithMockCustomLoginMember annotation) {
+
+    final SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+
+    Workspace workspace = Workspace.createDefaultWorkspace();
+    ReflectionTestUtils.setField(workspace, "id", annotation.workspaceId());
+
+    Member member = Member.builder()
+        .email(annotation.email())
+        .name(annotation.name())
+        .displayName(annotation.displayName())
+        .role(annotation.role())
+        .build();
+    ReflectionTestUtils.setField(member, "id", annotation.id());
+    ReflectionTestUtils.setField(member, "workspace", workspace);
+
+    final MemberDetails memberDetails = MemberDetails.create(member);
+
+    final UsernamePasswordAuthenticationToken authenticationToken =
+        new UsernamePasswordAuthenticationToken(
+            memberDetails,
+            "password",
+            memberDetails.getAuthorities());
+
+    securityContext.setAuthentication(authenticationToken);
+    return securityContext;
+  }
+}


### PR DESCRIPTION
* 멤버 상세 정보 조회 기능을 구현하였습니다.
*   `@WithMockCustomLoginMember` 애노테이션과   `WithMockCustomLoginMemberSecurityContextFactory` 클래스를 구현하였습니다.
  * `@WithMockCustomLoginMember` 애노테이션을 스프링 시큐리티가 적용된 컨트롤러 테스트 클래스 위에 붙여주면, 멤버 인증 정보가 포함된 상태로 테스트가 가능합니다.
    * `@WIthMockCustomLoginUser ` 애노테이션(이메일 인증만 진행한 유저)과 다릅니다.