### PR TITLE
[XS2-91(3)] white_check_mark: member 빌더 수정

### DIFF
--- a/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
@@ -676,9 +676,9 @@ class DefaultMemberServiceTest {
             .name("test")
             .displayName("test")
             .role(Role.ROLE_USER)
+            .workspace(workspace)
             .build();
         ReflectionTestUtils.setField(member, "id", 1L);
-        ReflectionTestUtils.setField(member, "workspace", workspace);
 
         //when, then
         assertThrows(IllegalArgumentException.class, () ->
@@ -701,9 +701,9 @@ class DefaultMemberServiceTest {
             .name("test")
             .displayName("test")
             .role(Role.ROLE_USER)
+            .workspace(workspace)
             .build();
         ReflectionTestUtils.setField(member, "id", 1L);
-        ReflectionTestUtils.setField(member, "workspace", workspace);
         final String encodedMemberId = "TESTID";
         given(idEncoder.decode(anyString())).willReturn(1L);
         given(repository.findByIdAndWorkspace_id(anyLong(), anyLong())).willReturn(Optional.empty());
@@ -729,9 +729,9 @@ class DefaultMemberServiceTest {
             .name("test")
             .displayName("test")
             .role(Role.ROLE_USER)
+            .workspace(workspace)
             .build();
         ReflectionTestUtils.setField(member, "id", 1L);
-        ReflectionTestUtils.setField(member, "workspace", workspace);
         final String encodedMemberId = "TESTID";
         final MemberResponse memberResponse = MemberResponse.builder()
             .encodedMemberId("TESTID")

--- a/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginMemberSecurityContextFactory.java
+++ b/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginMemberSecurityContextFactory.java
@@ -27,9 +27,9 @@ public class WithMockCustomLoginMemberSecurityContextFactory implements
         .name(annotation.name())
         .displayName(annotation.displayName())
         .role(annotation.role())
+        .workspace(workspace)
         .build();
     ReflectionTestUtils.setField(member, "id", annotation.id());
-    ReflectionTestUtils.setField(member, "workspace", workspace);
 
     final MemberDetails memberDetails = MemberDetails.create(member);
 


### PR DESCRIPTION
member 객체의 workspace 필드를 리플렉션으로 주입하는 것이 아니라, 빌더패턴으로 주입하는 것으로 수정하였습니다.