### PR TITLE
[XS2-83] 채널 목록 조회 기능

### DIFF
--- a/src/main/java/com/prgrms/be02slack/channel/controller/ChannelApiController.java
+++ b/src/main/java/com/prgrms/be02slack/channel/controller/ChannelApiController.java
@@ -1,11 +1,14 @@
 package com.prgrms.be02slack.channel.controller;
 
+import java.util.List;
+
 import javax.mail.MessagingException;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,10 +17,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.prgrms.be02slack.channel.controller.dto.ChannelResponse;
 import com.prgrms.be02slack.channel.controller.dto.ChannelSaveRequest;
 import com.prgrms.be02slack.channel.controller.dto.InviteRequest;
 import com.prgrms.be02slack.channel.service.ChannelService;
 import com.prgrms.be02slack.common.dto.AuthResponse;
+import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.security.CurrentMember;
 
 @Validated
 @RestController
@@ -52,5 +58,11 @@ public class ChannelApiController {
       @PathVariable @NotBlank String channelId,
       @RequestParam @NotBlank String token) {
     return channelService.participate(workspaceId, channelId, token);
+  }
+
+  @GetMapping
+  public List<ChannelResponse> findAllByMember(
+      @CurrentMember Member member) {
+    return channelService.findAllByMember(member);
   }
 }

--- a/src/main/java/com/prgrms/be02slack/channel/controller/dto/ChannelResponse.java
+++ b/src/main/java/com/prgrms/be02slack/channel/controller/dto/ChannelResponse.java
@@ -1,0 +1,28 @@
+package com.prgrms.be02slack.channel.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ChannelResponse {
+  private final String id;
+  private final String name;
+  private final boolean isPrivate;
+
+  public ChannelResponse(String id, String name, boolean isPrivate) {
+    this.id = id;
+    this.name = name;
+    this.isPrivate = isPrivate;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @JsonProperty("isPrivate")
+  public boolean isPrivate() {
+    return isPrivate;
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/channel/entity/Channel.java
+++ b/src/main/java/com/prgrms/be02slack/channel/entity/Channel.java
@@ -63,6 +63,14 @@ public class Channel extends BaseTime {
     return id;
   }
 
+  public String getName() {
+    return name;
+  }
+
+  public boolean isPrivate() {
+    return isPrivate;
+  }
+
   public void addSubscribeInfo(SubscribeInfo subscribeInfo) {
     subscribeInfos.add(subscribeInfo);
   }

--- a/src/main/java/com/prgrms/be02slack/channel/service/ChannelService.java
+++ b/src/main/java/com/prgrms/be02slack/channel/service/ChannelService.java
@@ -1,11 +1,15 @@
 package com.prgrms.be02slack.channel.service;
 
+import java.util.List;
+
 import javax.mail.MessagingException;
 
+import com.prgrms.be02slack.channel.controller.dto.ChannelResponse;
 import com.prgrms.be02slack.channel.controller.dto.ChannelSaveRequest;
 import com.prgrms.be02slack.channel.controller.dto.InviteRequest;
 import com.prgrms.be02slack.channel.entity.Channel;
 import com.prgrms.be02slack.common.dto.AuthResponse;
+import com.prgrms.be02slack.member.entity.Member;
 
 public interface ChannelService {
   String create(String workspaceId,
@@ -21,5 +25,7 @@ public interface ChannelService {
       String token);
 
   Channel findByKey(String key);
+
+  List<ChannelResponse> findAllByMember(Member member);
 }
 

--- a/src/main/java/com/prgrms/be02slack/subscribeInfo/repository/SubscribeInfoRepository.java
+++ b/src/main/java/com/prgrms/be02slack/subscribeInfo/repository/SubscribeInfoRepository.java
@@ -1,5 +1,6 @@
 package com.prgrms.be02slack.subscribeInfo.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,4 +21,7 @@ public interface SubscribeInfoRepository extends JpaRepository<SubscribeInfo, Lo
   @Query("select s from SubscribeInfo s where s.channel =:channel and s.member.name = :name")
   Optional<SubscribeInfo> existsByChannelAndMemberName(@Param("channel") Channel channel,
       @Param("name") String name);
+
+  @Query("select s from SubscribeInfo s join fetch s.channel join fetch s.member where s.member =:member")
+  List<SubscribeInfo> findAllByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/prgrms/be02slack/subscribeInfo/service/DefaultSubscribeInfoService.java
+++ b/src/main/java/com/prgrms/be02slack/subscribeInfo/service/DefaultSubscribeInfoService.java
@@ -2,6 +2,8 @@ package com.prgrms.be02slack.subscribeInfo.service;
 
 import static org.apache.logging.log4j.util.Strings.*;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -56,5 +58,12 @@ public class DefaultSubscribeInfoService implements SubscribeInfoService {
     Assert.isTrue(isNotBlank(name), "Name must be provided");
 
     return subscribeInfoRepository.existsByChannelAndMemberName(channel, name).isPresent();
+  }
+
+  @Override
+  public List<SubscribeInfo> findAllByMember(Member member) {
+    Assert.notNull(member, "Member must be provided");
+
+    return subscribeInfoRepository.findAllByMember(member);
   }
 }

--- a/src/main/java/com/prgrms/be02slack/subscribeInfo/service/SubscribeInfoService.java
+++ b/src/main/java/com/prgrms/be02slack/subscribeInfo/service/SubscribeInfoService.java
@@ -1,7 +1,10 @@
 package com.prgrms.be02slack.subscribeInfo.service;
 
+import java.util.List;
+
 import com.prgrms.be02slack.channel.entity.Channel;
 import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.subscribeInfo.entity.SubscribeInfo;
 
 public interface SubscribeInfoService {
 
@@ -12,4 +15,6 @@ public interface SubscribeInfoService {
   boolean isExistsByChannelAndMemberEmail(Channel channel, String email);
 
   boolean isExistsByChannelAndMemberName(Channel channel, String name);
+
+  List<SubscribeInfo> findAllByMember(Member member);
 }

--- a/src/test/java/com/prgrms/be02slack/channel/controller/ChannelApiControllerTest.java
+++ b/src/test/java/com/prgrms/be02slack/channel/controller/ChannelApiControllerTest.java
@@ -62,17 +62,6 @@ class ChannelApiControllerTest extends ControllerSetUp {
   @MockBean
   private ChannelService channelService;
 
-  static class PathVariableSourceBlank implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          Arguments.of(" "),
-          Arguments.of("\t"),
-          Arguments.of("\n")
-      );
-    }
-  }
-
   static class NameSourceOutOfRange implements ArgumentsProvider {
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
@@ -156,35 +145,6 @@ class ChannelApiControllerTest extends ControllerSetUp {
                         .description("whether the channel is open to the public")
                 )
             ));
-      }
-    }
-
-    @Nested
-    @DisplayName("workspaceId 가 빈 값 이거나 공백이라면")
-    class ContextWithWorkspaceIdBlank {
-
-      @ParameterizedTest
-      @ArgumentsSource(PathVariableSourceBlank.class)
-      @DisplayName("BadRequest 를 응답한다")
-      void ItResponseBadRequest(String workspaceId) throws Exception {
-        //given
-        HashMap<Object, Object> requestMap = new HashMap<>();
-        requestMap.put("name", "testName");
-        requestMap.put("description", "testDescription");
-        requestMap.put("isPrivate", false);
-
-        String requestBody = objectMapper.writeValueAsString(requestMap);
-
-        //when
-        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders.post(
-                API_URL + "workspaces/" + workspaceId + "/channels")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(requestBody);
-
-        ResultActions response = mockMvc.perform(request);
-
-        //then
-        response.andExpect(status().isBadRequest());
       }
     }
 
@@ -293,66 +253,6 @@ class ChannelApiControllerTest extends ControllerSetUp {
                         .description("list of invitees")
                 )
             ));
-      }
-    }
-
-    @Nested
-    @DisplayName("workspaceId 가 빈 값 이거나 공백이라면")
-    class ContextWithWorkspaceIdBlank {
-
-      @ParameterizedTest
-      @ArgumentsSource(PathVariableSourceBlank.class)
-      @DisplayName("BadRequest 를 응답한다")
-      void ItResponseBadRequest(String workspaceId) throws Exception {
-        //given
-        HashMap<String, Object> requestMap = new HashMap<>();
-        requestMap.put("sender", "testSenderName");
-        requestMap.put("inviteeInfos", Set.of("name1", "test@gmail.com"));
-
-        String requestBody = objectMapper.writeValueAsString(requestMap);
-
-        //when
-        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders.post(
-                API_URL + "/workspaces/{workspaceId}/channels/{channelId}/invite",
-                workspaceId, "channelId"
-            )
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(requestBody);
-
-        ResultActions response = mockMvc.perform(request);
-
-        //then
-        response.andExpect(status().isBadRequest());
-      }
-    }
-
-    @Nested
-    @DisplayName("channelId 가 빈 값 이거나 공백이라면")
-    class ContextWithChannelIdBlank {
-
-      @ParameterizedTest
-      @ArgumentsSource(PathVariableSourceBlank.class)
-      @DisplayName("BadRequest 를 응답한다")
-      void ItResponseBadRequest(String channelId) throws Exception {
-        //given
-        HashMap<String, Object> requestMap = new HashMap<>();
-        requestMap.put("sender", "testSenderName");
-        requestMap.put("inviteeInfos", Set.of("name1", "test@gmail.com"));
-
-        String requestBody = objectMapper.writeValueAsString(requestMap);
-
-        //when
-        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders.post(
-                API_URL + "/workspaces/{workspaceId}/channels/{channelId}/invite",
-                "workspaceId", channelId
-            )
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(requestBody);
-
-        ResultActions response = mockMvc.perform(request);
-
-        //then
-        response.andExpect(status().isBadRequest());
       }
     }
 
@@ -496,64 +396,6 @@ class ChannelApiControllerTest extends ControllerSetUp {
                     fieldWithPath("tokenType").type(JsonFieldType.STRING)
                         .description("token type")
                 )));
-      }
-    }
-
-    @Nested
-    @DisplayName("workspaceId 가 빈 값 이거나 공백이라면")
-    class ContextWithWorkspaceIdBlank {
-
-      @ParameterizedTest
-      @ArgumentsSource(PathVariableSourceBlank.class)
-      @DisplayName("BadRequest 를 응답한다")
-      void ItResponseBadRequest(String workspaceId) throws Exception {
-        //given
-        HashMap<String, Object> requestMap = new HashMap<>();
-        requestMap.put("token", "token");
-
-        String requestBody = objectMapper.writeValueAsString(requestMap);
-
-        //when
-        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders.post(
-                API_URL + "/workspaces/{workspaceId}/channels/{channelId}/participate?token={token}",
-                workspaceId, "channelId", "token"
-            )
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(requestBody);
-
-        ResultActions response = mockMvc.perform(request);
-
-        //then
-        response.andExpect(status().isBadRequest());
-      }
-    }
-
-    @Nested
-    @DisplayName("channelId 가 빈 값 이거나 공백이라면")
-    class ContextWithChannelIdBlank {
-
-      @ParameterizedTest
-      @ArgumentsSource(PathVariableSourceBlank.class)
-      @DisplayName("BadRequest 를 응답한다")
-      void ItResponseBadRequest(String channelId) throws Exception {
-        //given
-        HashMap<String, Object> requestMap = new HashMap<>();
-        requestMap.put("token", "token");
-
-        String requestBody = objectMapper.writeValueAsString(requestMap);
-
-        //when
-        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders.post(
-                API_URL + "/workspaces/{workspaceId}/channels/{channelId}/participate?token={token}",
-                "workspaceId", channelId, "token"
-            )
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(requestBody);
-
-        ResultActions response = mockMvc.perform(request);
-
-        //then
-        response.andExpect(status().isBadRequest());
       }
     }
 

--- a/src/test/java/com/prgrms/be02slack/channel/controller/ChannelApiControllerTest.java
+++ b/src/test/java/com/prgrms/be02slack/channel/controller/ChannelApiControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -20,13 +21,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.MockBeans;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
@@ -36,23 +34,22 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.be02slack.channel.controller.dto.ChannelResponse;
 import com.prgrms.be02slack.channel.controller.dto.ChannelSaveRequest;
 import com.prgrms.be02slack.channel.controller.dto.InviteRequest;
 import com.prgrms.be02slack.channel.exception.NameDuplicateException;
 import com.prgrms.be02slack.channel.service.ChannelService;
-import com.prgrms.be02slack.common.configuration.security.SecurityConfig;
 import com.prgrms.be02slack.common.dto.AuthResponse;
+import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.util.ControllerSetUp;
+import com.prgrms.be02slack.util.WithMockCustomLoginMember;
 
 @WebMvcTest(
-    controllers = ChannelApiController.class,
-    excludeAutoConfiguration = SecurityAutoConfiguration.class,
-    excludeFilters = {
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
-    }
+    controllers = ChannelApiController.class
 )
 @MockBeans({@MockBean(JpaMetamodelMappingContext.class)})
 @AutoConfigureRestDocs
-class ChannelApiControllerTest {
+class ChannelApiControllerTest extends ControllerSetUp {
   private static final String API_URL = "/api/v1/";
   private static final String CREATE_CHANNEL_URL = API_URL + "workspaces/testWorkspaceId/channels";
 
@@ -587,6 +584,43 @@ class ChannelApiControllerTest {
         //then
         response.andExpect(status().isBadRequest());
       }
+    }
+  }
+
+  @Nested
+  @WithMockCustomLoginMember
+  @DisplayName("findAllByMember 메서드는")
+  class DescribeFindAllByMember {
+
+    @Test
+    @DisplayName("멤버가 구독한 채널들을 응답한다")
+    void ItResponseSubscribedChannels() throws Exception {
+      //given
+      given(channelService.findAllByMember(any(Member.class)))
+          .willReturn(List.of(new ChannelResponse("SDFASD", "testName", false)));
+
+      //when
+      MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders.get(
+          API_URL + "/workspaces/{workspaceId}/channels",
+          "workspaceId"
+      );
+
+      ResultActions response = mockMvc.perform(request);
+
+      //then
+      verify(channelService).findAllByMember(any(Member.class));
+      response.andExpect(status().isOk())
+          .andDo(document("Look up channel",
+              pathParameters(
+                  parameterWithName("workspaceId").description("workspace id")
+              ),
+              responseFields(
+                  fieldWithPath("[].id").type(JsonFieldType.STRING).description("channel id"),
+                  fieldWithPath("[].name").type(JsonFieldType.STRING)
+                      .description("channel name"),
+                  fieldWithPath("[].isPrivate").type(JsonFieldType.BOOLEAN)
+                      .description("whether the channel is open or not")
+              )));
     }
   }
 }

--- a/src/test/java/com/prgrms/be02slack/channel/controller/ChannelApiControllerTest.java
+++ b/src/test/java/com/prgrms/be02slack/channel/controller/ChannelApiControllerTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.MockBeans;
@@ -29,7 +28,6 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
@@ -48,16 +46,12 @@ import com.prgrms.be02slack.util.WithMockCustomLoginMember;
     controllers = ChannelApiController.class
 )
 @MockBeans({@MockBean(JpaMetamodelMappingContext.class)})
-@AutoConfigureRestDocs
 class ChannelApiControllerTest extends ControllerSetUp {
   private static final String API_URL = "/api/v1/";
   private static final String CREATE_CHANNEL_URL = API_URL + "workspaces/testWorkspaceId/channels";
 
   @Autowired
   private ObjectMapper objectMapper;
-
-  @Autowired
-  private MockMvc mockMvc;
 
   @MockBean
   private ChannelService channelService;

--- a/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/member/service/DefaultMemberServiceTest.java
@@ -676,9 +676,9 @@ class DefaultMemberServiceTest {
             .name("test")
             .displayName("test")
             .role(Role.ROLE_USER)
+            .workspace(workspace)
             .build();
         ReflectionTestUtils.setField(member, "id", 1L);
-        ReflectionTestUtils.setField(member, "workspace", workspace);
 
         //when, then
         assertThrows(IllegalArgumentException.class, () ->
@@ -701,9 +701,9 @@ class DefaultMemberServiceTest {
             .name("test")
             .displayName("test")
             .role(Role.ROLE_USER)
+            .workspace(workspace)
             .build();
         ReflectionTestUtils.setField(member, "id", 1L);
-        ReflectionTestUtils.setField(member, "workspace", workspace);
         final String encodedMemberId = "TESTID";
         given(idEncoder.decode(anyString())).willReturn(1L);
         given(repository.findByIdAndWorkspace_id(anyLong(), anyLong())).willReturn(Optional.empty());
@@ -729,9 +729,9 @@ class DefaultMemberServiceTest {
             .name("test")
             .displayName("test")
             .role(Role.ROLE_USER)
+            .workspace(workspace)
             .build();
         ReflectionTestUtils.setField(member, "id", 1L);
-        ReflectionTestUtils.setField(member, "workspace", workspace);
         final String encodedMemberId = "TESTID";
         final MemberResponse memberResponse = MemberResponse.builder()
             .encodedMemberId("TESTID")

--- a/src/test/java/com/prgrms/be02slack/subscribeInfo/service/DefaultSubscribeInfoServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/subscribeInfo/service/DefaultSubscribeInfoServiceTest.java
@@ -532,4 +532,53 @@ class DefaultSubscribeInfoServiceTest {
       }
     }
   }
+
+  @Nested
+  @DisplayName("findAllByMember 메서드는")
+  class DescribeFindAllByMember {
+
+    @Test
+    @DisplayName("멤버의 구독 정보들을 반환한다")
+    void ItReturnsSubscribeInfos() {
+      //given
+      Workspace workspace = Workspace.createDefaultWorkspace();
+      Member member = Member.builder()
+          .email("test@naver.com")
+          .name("test")
+          .displayName("test")
+          .role(Role.ROLE_OWNER)
+          .workspace(workspace)
+          .build();
+      Channel channel = Channel.builder()
+          .workspace(workspace)
+          .description("test")
+          .name("test")
+          .isPrivate(true)
+          .owner(member)
+          .build();
+      List<SubscribeInfo> createdSubscribeInfos = List.of(SubscribeInfo.subscribe(channel, member));
+      given(subscribeInfoRepository.findAllByMember(any(Member.class)))
+          .willReturn(createdSubscribeInfos);
+
+      //when
+      List<SubscribeInfo> subscribeInfos = subscribeInfoService.findAllByMember(member);
+
+      //then
+      verify(subscribeInfoRepository).findAllByMember(any(Member.class));
+      assertThat(subscribeInfos).isEqualTo(createdSubscribeInfos);
+    }
+
+    @Nested
+    @DisplayName("member 값이 null 이라면")
+    class ContextWithMemberNull {
+      @Test
+      @DisplayName("IllegalArgumentException 에러를 발생시킨다")
+      void ItThrowsIllegalArgumentException() {
+        //given
+        //when, then
+        assertThrows(IllegalArgumentException.class,
+            () -> subscribeInfoService.findAllByMember(null));
+      }
+    }
+  }
 }

--- a/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginMemberSecurityContextFactory.java
+++ b/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginMemberSecurityContextFactory.java
@@ -27,9 +27,9 @@ public class WithMockCustomLoginMemberSecurityContextFactory implements
         .name(annotation.name())
         .displayName(annotation.displayName())
         .role(annotation.role())
+        .workspace(workspace)
         .build();
     ReflectionTestUtils.setField(member, "id", annotation.id());
-    ReflectionTestUtils.setField(member, "workspace", workspace);
 
     final MemberDetails memberDetails = MemberDetails.create(member);
 


### PR DESCRIPTION
## 구현한 부분
* 채널 조회 기능을 어디 도메인에서 구현해야 할지 레이님께 물어보고 고민해 본 결과 **URI를 통해 리소스 식별**이 돼야 한다는 점에서 Channel 도메인이 가지는 게 가장 적절하다고 생각했습니다.

* 서비스 로직
    * ChannelService에서 SubscribeInfoService를 사용합니다. 
    * subscribeInfoService에 멤버의 구독정보를 조회하는 메서드를 만들고 ChannelService에서 해당 메서드를 호출한 다음 subscribeInfo.getChannel()로 채널 정보를 조회합니다. subscribeInfoRepository에서 구독 정보를 조회할 때 fetch join을 이용해서 channel 정보를 한번에 조회해오도록 했습니다.
        ```java
      Hibernate: 
          select
              subscribei0_.id as id1_4_0_,
              channel1_.id as id1_0_1_,
              member2_.id as id1_2_2_,
              subscribei0_.channel_id as channel_2_4_0_,
              subscribei0_.member_id as member_i3_4_0_,
              channel1_.created_at as created_2_0_1_,
              channel1_.updated_at as updated_3_0_1_,
              channel1_.description as descript4_0_1_,
              channel1_.is_private as is_priva5_0_1_,
              channel1_.name as name6_0_1_,
              channel1_.member_id as member_i7_0_1_,
              channel1_.workspace_id as workspac8_0_1_,
              member2_.created_at as created_2_2_2_,
              member2_.updated_at as updated_3_2_2_,
              member2_.display_name as display_4_2_2_,
              member2_.email as email5_2_2_,
              member2_.name as name6_2_2_,
              member2_.role as role7_2_2_,
              member2_.workspace_id as workspac8_2_2_ 
          from
              subscribe_info subscribei0_ 
          inner join
              channel channel1_ 
                  on subscribei0_.channel_id=channel1_.id 
          inner join
              member member2_ 
                  on subscribei0_.member_id=member2_.id 
          where
              subscribei0_.member_id=?
      ```
    * fetch join으로 channel 정보를 함께 조회해 오기 때문에 channelService에서 subscribeInfo.getChannel() 을 통해 채널 정보를 조회해도 추가 조회 쿼리가 발생하지 않습니다.
     

## 이전 코드 수정한 부분
* Service에 빠진 @Transactional 을 추가했습니다.
* 테스트를 위해  security 설정을 추가하면서 PathVariable 값에 공백이 들어올 때를 확인하는 테스트가 깨지는 문제가 발생했습니다.
* 현재 ChannelApiControlle의 모든 메서드가 security filter chain이 적용되기 때문에 security 적용으로 실패하는 테스트들은 삭제하였습니다. 
* 참고
https://gwanhyeon.github.io/Spring-20210528-spring-double-slash/