### PR TITLE
[XS2-105] DM채널 조회 기능 테스트코드 , 기능 구현 

### DIFF
--- a/src/main/java/com/prgrms/be02slack/directmessagechannel/controller/DirectMessageChannelApiController.java
+++ b/src/main/java/com/prgrms/be02slack/directmessagechannel/controller/DirectMessageChannelApiController.java
@@ -1,15 +1,19 @@
 package com.prgrms.be02slack.directmessagechannel.controller;
 
+import java.util.List;
+
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.prgrms.be02slack.directmessagechannel.controller.dto.DirectMessageChannelResponse;
 import com.prgrms.be02slack.directmessagechannel.service.DirectMessageChannelService;
 import com.prgrms.be02slack.member.entity.Member;
 import com.prgrms.be02slack.security.CurrentMember;
@@ -33,5 +37,13 @@ public class DirectMessageChannelApiController {
       @RequestParam @NotBlank @Email String receiverEmail
   ) {
     return directMessageChannelService.create(workspaceId, receiverEmail, member);
+  }
+
+  @GetMapping
+  public List<DirectMessageChannelResponse> getChannels(
+      @PathVariable @NotBlank String workspaceId,
+      @CurrentMember Member member
+  ) {
+    return directMessageChannelService.getChannels(member);
   }
 }

--- a/src/main/java/com/prgrms/be02slack/directmessagechannel/controller/dto/DirectMessageChannelResponse.java
+++ b/src/main/java/com/prgrms/be02slack/directmessagechannel/controller/dto/DirectMessageChannelResponse.java
@@ -9,4 +9,12 @@ public class DirectMessageChannelResponse {
     this.memberName = memberName;
     this.encodedDirectMessageChannelId = encodedDirectMessageChannelId;
   }
+
+  public String getMemberName() {
+    return memberName;
+  }
+
+  public String getEncodedDirectMessageChannelId() {
+    return encodedDirectMessageChannelId;
+  }
 }

--- a/src/main/java/com/prgrms/be02slack/directmessagechannel/controller/dto/DirectMessageChannelResponse.java
+++ b/src/main/java/com/prgrms/be02slack/directmessagechannel/controller/dto/DirectMessageChannelResponse.java
@@ -1,0 +1,12 @@
+package com.prgrms.be02slack.directmessagechannel.controller.dto;
+
+public class DirectMessageChannelResponse {
+
+  private final String memberName;
+  private final String encodedDirectMessageChannelId;
+
+  public DirectMessageChannelResponse(String memberName, String encodedDirectMessageChannelId) {
+    this.memberName = memberName;
+    this.encodedDirectMessageChannelId = encodedDirectMessageChannelId;
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/directmessagechannel/entity/DirectMessageChannel.java
+++ b/src/main/java/com/prgrms/be02slack/directmessagechannel/entity/DirectMessageChannel.java
@@ -1,7 +1,5 @@
 package com.prgrms.be02slack.directmessagechannel.entity;
 
-import static org.apache.logging.log4j.util.Strings.*;
-
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;

--- a/src/main/java/com/prgrms/be02slack/directmessagechannel/entity/DirectMessageChannel.java
+++ b/src/main/java/com/prgrms/be02slack/directmessagechannel/entity/DirectMessageChannel.java
@@ -50,4 +50,12 @@ public class DirectMessageChannel extends BaseTime {
   public Long getId() {
     return id;
   }
+
+  public Member getFirstMember() {
+    return firstMember;
+  }
+
+  public Member getSecondMember() {
+    return secondMember;
+  }
 }

--- a/src/main/java/com/prgrms/be02slack/directmessagechannel/repository/DirectMessageChannelRepository.java
+++ b/src/main/java/com/prgrms/be02slack/directmessagechannel/repository/DirectMessageChannelRepository.java
@@ -1,5 +1,6 @@
 package com.prgrms.be02slack.directmessagechannel.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,8 @@ public interface DirectMessageChannelRepository extends JpaRepository<DirectMess
   Optional<DirectMessageChannel> findByFirstMemberAndSecondMember(
       @Param("firstMember") Member firstMember,
       @Param("secondMember") Member secondMember);
+
+  @Query("select d from DirectMessageChannel d where (d.firstMember = :member)"
+      + "or (d.secondMember = :member)")
+  List<DirectMessageChannel> findAllByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/prgrms/be02slack/directmessagechannel/service/DefaultDirectMessageChannelService.java
+++ b/src/main/java/com/prgrms/be02slack/directmessagechannel/service/DefaultDirectMessageChannelService.java
@@ -5,7 +5,6 @@ import static org.apache.logging.log4j.util.Strings.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -16,7 +15,6 @@ import com.prgrms.be02slack.directmessagechannel.entity.DirectMessageChannel;
 import com.prgrms.be02slack.directmessagechannel.repository.DirectMessageChannelRepository;
 import com.prgrms.be02slack.member.entity.Member;
 import com.prgrms.be02slack.member.service.MemberService;
-import com.prgrms.be02slack.security.MemberDetails;
 import com.prgrms.be02slack.workspace.entity.Workspace;
 import com.prgrms.be02slack.workspace.service.WorkspaceService;
 

--- a/src/main/java/com/prgrms/be02slack/directmessagechannel/service/DefaultDirectMessageChannelService.java
+++ b/src/main/java/com/prgrms/be02slack/directmessagechannel/service/DefaultDirectMessageChannelService.java
@@ -2,12 +2,16 @@ package com.prgrms.be02slack.directmessagechannel.service;
 
 import static org.apache.logging.log4j.util.Strings.*;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import com.prgrms.be02slack.common.util.IdEncoder;
+import com.prgrms.be02slack.directmessagechannel.controller.dto.DirectMessageChannelResponse;
 import com.prgrms.be02slack.directmessagechannel.entity.DirectMessageChannel;
 import com.prgrms.be02slack.directmessagechannel.repository.DirectMessageChannelRepository;
 import com.prgrms.be02slack.member.entity.Member;
@@ -52,5 +56,20 @@ public class DefaultDirectMessageChannelService implements DirectMessageChannelS
             .orElseGet(() -> new DirectMessageChannel(sender, receiver, workspace));
 
     return idEncoder.encode(directMessageChannel.getId());
+  }
+
+  @Override
+  public List<DirectMessageChannelResponse> getChannels(Member member) {
+    Assert.notNull(member, "member must be provided");
+
+    return directMessageChannelRepository.findAllByMember(member).stream()
+        .map(c -> {
+          String encodedDMChannelId = idEncoder.encode(c.getId());
+          return c.getFirstMember().equals(member) ?
+              new DirectMessageChannelResponse(c.getSecondMember().getName(),
+                  encodedDMChannelId) :
+              new DirectMessageChannelResponse(c.getFirstMember().getName(),
+                  encodedDMChannelId);
+        }).collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/prgrms/be02slack/directmessagechannel/service/DirectMessageChannelService.java
+++ b/src/main/java/com/prgrms/be02slack/directmessagechannel/service/DirectMessageChannelService.java
@@ -3,9 +3,6 @@ package com.prgrms.be02slack.directmessagechannel.service;
 import java.util.List;
 
 import com.prgrms.be02slack.directmessagechannel.controller.dto.DirectMessageChannelResponse;
-import com.prgrms.be02slack.directmessagechannel.entity.DirectMessageChannel;
-import com.prgrms.be02slack.member.entity.Member;
-
 import com.prgrms.be02slack.member.entity.Member;
 
 public interface DirectMessageChannelService {

--- a/src/main/java/com/prgrms/be02slack/directmessagechannel/service/DirectMessageChannelService.java
+++ b/src/main/java/com/prgrms/be02slack/directmessagechannel/service/DirectMessageChannelService.java
@@ -1,8 +1,16 @@
 package com.prgrms.be02slack.directmessagechannel.service;
 
+import java.util.List;
+
+import com.prgrms.be02slack.directmessagechannel.controller.dto.DirectMessageChannelResponse;
+import com.prgrms.be02slack.directmessagechannel.entity.DirectMessageChannel;
+import com.prgrms.be02slack.member.entity.Member;
+
 import com.prgrms.be02slack.member.entity.Member;
 
 public interface DirectMessageChannelService {
 
   String create(String workspaceId, String receiverEmail, Member sender);
+
+  List<DirectMessageChannelResponse> getChannels(Member member);
 }

--- a/src/main/java/com/prgrms/be02slack/member/entity/Member.java
+++ b/src/main/java/com/prgrms/be02slack/member/entity/Member.java
@@ -142,4 +142,8 @@ public class Member extends BaseTime {
   public int hashCode() {
     return Objects.hash(id);
   }
+
+  public Workspace getWorkspace() {
+    return workspace;
+  }
 }

--- a/src/main/java/com/prgrms/be02slack/member/entity/Member.java
+++ b/src/main/java/com/prgrms/be02slack/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.prgrms.be02slack.member.entity;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
@@ -81,10 +82,6 @@ public class Member extends BaseTime {
     return role.name();
   }
 
-  public Workspace getWorkspace() {
-    return workspace;
-  }
-
   public void addSubscribeInfo(SubscribeInfo subscribeInfo) {
     subscribeInfos.add(subscribeInfo);
   }
@@ -129,5 +126,20 @@ public class Member extends BaseTime {
 
   public static Builder builder() {
     return new Builder();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    Member member = (Member)o;
+    return id.equals(member.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
   }
 }

--- a/src/test/java/com/prgrms/be02slack/directmessagechannel/service/DirectMessageChannelServiceTest.java
+++ b/src/test/java/com/prgrms/be02slack/directmessagechannel/service/DirectMessageChannelServiceTest.java
@@ -339,7 +339,6 @@ public class DirectMessageChannelServiceTest {
             .role(Role.ROLE_USER)
             .workspace(workspace)
             .build();
-        ReflectionTestUtils.setField(member, "id", 1L);
 
         final List<DirectMessageChannel> emptyList = List.of();
         when(directMessageChannelRepository.findAllByMember(any())).thenReturn(emptyList);


### PR DESCRIPTION
# DM채널 조회 기능

슬랙의 DM채널은 사용자 멤버 이름과 프로필사진이 보입니다.
<img width="351" alt="image" src="https://user-images.githubusercontent.com/57293011/177224521-7b06ba89-9ce1-4bb7-bc95-29c2a55b1f61.png">

특정 채널을 클릭시 아래의 요청을 보내고 해당 멤버와 이전에 대화한 채널이 존재한다면 그 채널을 응답해주며 한 번도 대화한적이 없으면 DM채널을 새로 생성해서 응답해주는걸로 보입니다. (각 채널의 ID로 확인해봤습니다.)
<img width="381" alt="image" src="https://user-images.githubusercontent.com/57293011/177224614-1ea31efd-5c48-48b8-b7fe-aa23219909fa.png">

이 요청을 클론 구현한 api는 저번 PR에 올렸던 채널 생성 api고 이번 PR은 채널 목록 조회를 위한 api입니다.

get요청을 받으면 현재 로그인한 멤버의 DM채널들을 조회하여 자기 자신이 아닌 다른 멤버의 이름과 채널 ID를  ResponseDto에 응답하도록 했습니다.

# 짱짱 팀원들께 질문 🙇 
```
  @GetMapping
  public List<DirectMessageChannelResponse> getChannels(
      @PathVariable @NotBlank String workspaceId,
      @CurrentMember Member member
  ) {
    return directMessageChannelService.getChannels(member);
  }

```
PathVariable로 받는 workspaceId는 사용되지 않습니다. 혹시 이 부분은 테스트 작성시 고려하지 않아도 될까요?