### PR TITLE
[XS2-164] MessageWebSocketController 시큐리티 적용 작성자 정보 가져오는 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/be02slack/common/configuration/websocket/StompHandler.java
+++ b/src/main/java/com/prgrms/be02slack/common/configuration/websocket/StompHandler.java
@@ -1,0 +1,61 @@
+package com.prgrms.be02slack.common.configuration.websocket;
+
+import java.util.Objects;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import com.prgrms.be02slack.security.DefaultUserDetailsService;
+import com.prgrms.be02slack.security.TokenProvider;
+
+@Component
+public class StompHandler implements ChannelInterceptor {
+
+  private final TokenProvider tokenProvider;
+  private final DefaultUserDetailsService customUserDetailsService;
+
+  public StompHandler(
+      TokenProvider tokenProvider,
+      DefaultUserDetailsService customUserDetailsService
+  ) {
+    this.tokenProvider = tokenProvider;
+    this.customUserDetailsService = customUserDetailsService;
+  }
+
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+    StompHeaderAccessor accessor =
+        MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+    if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+      final var token = Objects.requireNonNull(accessor.getFirstNativeHeader("Authorization"))
+          .substring(7);
+      tokenProvider.validateToken(token);
+
+      final String email = tokenProvider.getEmailFromToken(token);
+      final String encodedWorkspaceId = tokenProvider.getEncodedWorkspaceIdFromToken(token);
+      final String tokenPayloadStr = email + " " + encodedWorkspaceId;
+      final UserDetails userDetails = customUserDetailsService.loadUserByUsername(tokenPayloadStr);
+
+      if (userDetails == null) {
+        throw new AccessDeniedException("Invalid User token");
+      }
+
+      UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+          userDetails,
+          null,
+          userDetails.getAuthorities()
+      );
+      accessor.setUser(authentication);
+    }
+    return message;
+  }
+}

--- a/src/main/java/com/prgrms/be02slack/common/configuration/websocket/WebSocketConfig.java
+++ b/src/main/java/com/prgrms/be02slack/common/configuration/websocket/WebSocketConfig.java
@@ -1,6 +1,9 @@
 package com.prgrms.be02slack.common.configuration.websocket;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -10,6 +13,12 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+  private final StompHandler stompHandler;
+
+  public WebSocketConfig(StompHandler stompHandler) {
+    this.stompHandler = stompHandler;
+  }
+
   @Override
   public void configureMessageBroker(MessageBrokerRegistry registry) {
     registry.enableSimpleBroker("/topic", "/queue");
@@ -18,8 +27,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
-    registry.addEndpoint("/ws-stomp")
-        .setAllowedOrigins("*")
-        .withSockJS();
+    registry.addEndpoint("/ws-stomp").setAllowedOrigins("*").withSockJS();
+  }
+
+  @Override
+  @Order(Ordered.HIGHEST_PRECEDENCE + 99)
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+    registration.interceptors(stompHandler);
   }
 }

--- a/src/main/java/com/prgrms/be02slack/message/controller/MessageWebsocketController.java
+++ b/src/main/java/com/prgrms/be02slack/message/controller/MessageWebsocketController.java
@@ -1,5 +1,7 @@
 package com.prgrms.be02slack.message.controller;
 
+import java.security.Principal;
+
 import javax.validation.Valid;
 
 import org.slf4j.Logger;
@@ -31,11 +33,14 @@ public class MessageWebsocketController {
   @SendTo("/topic/channel.{encodedChannelId}")
   public MessageWebsocketResponse sendMessage(
       @DestinationVariable String encodedChannelId,
-      @Valid MessageWebsocketRequest channelMessageRequest
+      @Valid MessageWebsocketRequest channelMessageRequest,
+      Principal principal
   ) {
-    log.info("channel id : {}, content : {}", encodedChannelId, channelMessageRequest.getContent());
+    final var senderEmail = principal.getName();
+    log.info("sender email : {}, channel id : {}, content : {}", senderEmail, encodedChannelId,
+        channelMessageRequest.getContent());
 
-    final var sendMessage = messageService.sendMessage(encodedChannelId,
+    final var sendMessage = messageService.sendMessage(senderEmail, encodedChannelId,
         channelMessageRequest.getContent());
 
     return MessageWebsocketResponse.from(sendMessage);

--- a/src/main/java/com/prgrms/be02slack/message/controller/MessageWebsocketController.java
+++ b/src/main/java/com/prgrms/be02slack/message/controller/MessageWebsocketController.java
@@ -11,12 +11,15 @@ import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
 
+import com.prgrms.be02slack.member.entity.Member;
 import com.prgrms.be02slack.message.controller.dto.MessageWebsocketRequest;
 import com.prgrms.be02slack.message.controller.dto.MessageWebsocketResponse;
 import com.prgrms.be02slack.message.service.MessageService;
+import com.prgrms.be02slack.security.MemberDetails;
 
 @Validated
 @Controller
@@ -36,11 +39,9 @@ public class MessageWebsocketController {
       @Valid MessageWebsocketRequest channelMessageRequest,
       Principal principal
   ) {
-    final var senderEmail = principal.getName();
-    log.info("sender email : {}, channel id : {}, content : {}", senderEmail, encodedChannelId,
-        channelMessageRequest.getContent());
+    final var member = getMember(principal);
 
-    final var sendMessage = messageService.sendMessage(senderEmail, encodedChannelId,
+    final var sendMessage = messageService.sendMessage(member, encodedChannelId,
         channelMessageRequest.getContent());
 
     return MessageWebsocketResponse.from(sendMessage);
@@ -52,4 +53,9 @@ public class MessageWebsocketController {
     log.info(e.toString());
     return MessageWebsocketResponse.error(e.getMessage());
   }
+
+  private Member getMember(Principal principal) {
+    return ((MemberDetails)((Authentication)principal).getPrincipal()).getMember();
+  }
+
 }

--- a/src/main/java/com/prgrms/be02slack/message/service/DefaultMessageService.java
+++ b/src/main/java/com/prgrms/be02slack/message/service/DefaultMessageService.java
@@ -8,7 +8,7 @@ import com.prgrms.be02slack.message.entity.Message;
 public class DefaultMessageService implements MessageService {
 
   @Override
-  public Message sendMessage(String encodedChannelId, String content) {
+  public Message sendMessage(String senderEmail, String encodedChannelId, String content) {
     return null;
   }
 }

--- a/src/main/java/com/prgrms/be02slack/message/service/DefaultMessageService.java
+++ b/src/main/java/com/prgrms/be02slack/message/service/DefaultMessageService.java
@@ -2,13 +2,14 @@ package com.prgrms.be02slack.message.service;
 
 import org.springframework.stereotype.Service;
 
+import com.prgrms.be02slack.member.entity.Member;
 import com.prgrms.be02slack.message.entity.Message;
 
 @Service
 public class DefaultMessageService implements MessageService {
 
   @Override
-  public Message sendMessage(String senderEmail, String encodedChannelId, String content) {
+  public Message sendMessage(Member member, String encodedChannelId, String content) {
     return null;
   }
 }

--- a/src/main/java/com/prgrms/be02slack/message/service/MessageService.java
+++ b/src/main/java/com/prgrms/be02slack/message/service/MessageService.java
@@ -4,5 +4,5 @@ import com.prgrms.be02slack.message.entity.Message;
 
 public interface MessageService {
 
-  Message sendMessage(String encodedChannelId, String content);
+  Message sendMessage(String senderEmail, String encodedChannelId, String content);
 }

--- a/src/main/java/com/prgrms/be02slack/message/service/MessageService.java
+++ b/src/main/java/com/prgrms/be02slack/message/service/MessageService.java
@@ -1,8 +1,9 @@
 package com.prgrms.be02slack.message.service;
 
+import com.prgrms.be02slack.member.entity.Member;
 import com.prgrms.be02slack.message.entity.Message;
 
 public interface MessageService {
 
-  Message sendMessage(String senderEmail, String encodedChannelId, String content);
+  Message sendMessage(Member member, String encodedChannelId, String content);
 }

--- a/src/test/java/com/prgrms/be02slack/message/controller/MessageWebsocketControllerTest.java
+++ b/src/test/java/com/prgrms/be02slack/message/controller/MessageWebsocketControllerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
@@ -24,6 +25,7 @@ import org.springframework.messaging.simp.stomp.StompFrameHandler;
 import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.web.socket.WebSocketHttpHeaders;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
 import org.springframework.web.socket.sockjs.client.SockJsClient;
@@ -35,6 +37,9 @@ import com.prgrms.be02slack.message.controller.dto.MessageWebsocketRequest;
 import com.prgrms.be02slack.message.controller.dto.MessageWebsocketResponse;
 import com.prgrms.be02slack.message.entity.Message;
 import com.prgrms.be02slack.message.service.MessageService;
+import com.prgrms.be02slack.security.DefaultUserDetailsService;
+import com.prgrms.be02slack.security.MemberDetails;
+import com.prgrms.be02slack.security.TokenProvider;
 import com.prgrms.be02slack.workspace.entity.Workspace;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -42,8 +47,14 @@ class MessageWebsocketControllerTest {
 
   static final String WS_URI = "ws://localhost:8080/ws-stomp";
 
+  @Autowired
+  private TokenProvider tokenProvider;
+
   @MockBean
   private MessageService messageService;
+
+  @MockBean
+  private DefaultUserDetailsService userDetailsService;
 
   private BlockingQueue<Object> blockingQueue;
   private WebSocketStompClient stompClient;
@@ -101,8 +112,15 @@ class MessageWebsocketControllerTest {
       @DisplayName("해당 메시지를 발행한다")
       void ItPublishMessage() throws Exception {
         //given
-        StompSession session = stompClient.connect(WS_URI, getStompSessionHandlerAdapter())
-            .get(1, SECONDS);
+        final var memberDetails = MemberDetails.create(testMember);
+        given(userDetailsService.loadUserByUsername(anyString())).willReturn(memberDetails);
+
+        WebSocketHttpHeaders handshakeHeaders = new WebSocketHttpHeaders();
+        StompHeaders connectHeaders = new StompHeaders();
+        final var token = tokenProvider.createMemberToken("test@test.com", "TEST");
+        connectHeaders.add("Authorization", "Bearer: " + token);
+        StompSession session = stompClient.connect(WS_URI, handshakeHeaders, connectHeaders,
+            getStompSessionHandlerAdapter()).get(1, SECONDS);
 
         String subUrl = MessageFormat.format("/topic/channel.{0}", "TEST");
         session.subscribe(subUrl, getStompFrameHandler(MessageWebsocketResponse.class));
@@ -111,7 +129,8 @@ class MessageWebsocketControllerTest {
             .encodedChannelId("TEST123")
             .member(testMember)
             .content("test").build();
-        given(messageService.sendMessage(anyString(), anyString())).willReturn(message);
+        given(messageService.sendMessage(anyString(), anyString(), anyString())).willReturn(
+            message);
 
         //when
         String pubUrl = MessageFormat.format("/app/channel.{0}", "TEST");
@@ -140,8 +159,15 @@ class MessageWebsocketControllerTest {
       @DisplayName("에러메시지를 유저에게 반환한다")
       void ItPublishMessage(String src) throws Exception {
         //given
-        StompSession session = stompClient.connect(WS_URI, getStompSessionHandlerAdapter())
-            .get(1, SECONDS);
+        final var memberDetails = MemberDetails.create(testMember);
+        given(userDetailsService.loadUserByUsername(anyString())).willReturn(memberDetails);
+
+        WebSocketHttpHeaders handshakeHeaders = new WebSocketHttpHeaders();
+        StompHeaders connectHeaders = new StompHeaders();
+        final var token = tokenProvider.createMemberToken("test@test.com", "TEST");
+        connectHeaders.add("Authorization", "Bearer: " + token);
+        StompSession session = stompClient.connect(WS_URI, handshakeHeaders, connectHeaders,
+            getStompSessionHandlerAdapter()).get(1, SECONDS);
 
         String subUrl = "/user/queue.error";
         session.subscribe(subUrl, getStompFrameHandler(MessageWebsocketResponse.class));
@@ -150,7 +176,8 @@ class MessageWebsocketControllerTest {
             .encodedChannelId("TEST123")
             .member(testMember)
             .content("test").build();
-        given(messageService.sendMessage(anyString(), anyString())).willReturn(message);
+        given(messageService.sendMessage(anyString(), anyString(), anyString())).willReturn(
+            message);
 
         //when
         String pubUrl = MessageFormat.format("/app/channel.{0}", "TEST");

--- a/src/test/java/com/prgrms/be02slack/message/controller/MessageWebsocketControllerTest.java
+++ b/src/test/java/com/prgrms/be02slack/message/controller/MessageWebsocketControllerTest.java
@@ -129,7 +129,7 @@ class MessageWebsocketControllerTest {
             .encodedChannelId("TEST123")
             .member(testMember)
             .content("test").build();
-        given(messageService.sendMessage(anyString(), anyString(), anyString())).willReturn(
+        given(messageService.sendMessage(any(Member.class), anyString(), anyString())).willReturn(
             message);
 
         //when
@@ -176,7 +176,7 @@ class MessageWebsocketControllerTest {
             .encodedChannelId("TEST123")
             .member(testMember)
             .content("test").build();
-        given(messageService.sendMessage(anyString(), anyString(), anyString())).willReturn(
+        given(messageService.sendMessage(any(Member.class), anyString(), anyString())).willReturn(
             message);
 
         //when

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -15,3 +15,6 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
         format_sql: true
     show-sql: true
+jwt:
+  tokenSecret: EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ
+  tokenExpirationMsec: 1800000


### PR DESCRIPTION
`@CurrentMember`어노테이션으로 사용자 정보를 가져오는 방법을 찾지못해서 우선 Principle 파라미터로 사용자 정보(이메일)을 받은후 서비스 레이어에서 email 로 멤버를 조회하는 방식으로 구현할 생각입니다.

- 클라이언트가 JWT 토큰을 stomp 메시지의 헤더에 같이 보내면, `StompHandler`클래스가 헤더에 접근하여 jwt 토큰에 대한 검증을 진행하고 현제 세션에 jwt의 사용자 정보(이메일)를 추가하게 됩니다