### PR TITLE
[XS2-166] WorkspaceApiController 테스트 시큐리티 적용

### DIFF
--- a/src/main/java/com/prgrms/be02slack/common/configuration/security/SecurityConfig.java
+++ b/src/main/java/com/prgrms/be02slack/common/configuration/security/SecurityConfig.java
@@ -62,6 +62,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
           .hasAnyRole(USER, OWNER)
         .antMatchers(HttpMethod.GET, "/api/v1/channels/{encodedChannelId}/members")
           .hasAnyRole(USER, OWNER)
+        .antMatchers(HttpMethod.PUT,"/api/v1/workspaces/**")
+          .hasRole(OWNER)
         .antMatchers("/api/v1/workspaces/{encodedWorkspaceId}/channels/**")
           .hasAnyRole(USER, OWNER)
           .anyRequest().permitAll()

--- a/src/main/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceService.java
+++ b/src/main/java/com/prgrms/be02slack/workspace/service/DefaultWorkspaceService.java
@@ -20,8 +20,10 @@ public class DefaultWorkspaceService implements WorkspaceService {
   private final IdEncoder idEncoder;
   private final WorkspaceRepository workspaceRepository;
 
-  public DefaultWorkspaceService(IdEncoder idEncoder,
-                                 WorkspaceRepository workspaceRepository) {
+  public DefaultWorkspaceService(
+      IdEncoder idEncoder,
+      WorkspaceRepository workspaceRepository
+  ) {
     this.idEncoder = idEncoder;
     this.workspaceRepository = workspaceRepository;
     ;
@@ -57,7 +59,7 @@ public class DefaultWorkspaceService implements WorkspaceService {
     final var id = idEncoder.decode(key);
 
     return workspaceRepository.findById(id)
-                              .orElseThrow(() -> new NotFoundException("Workspace not found"));
+        .orElseThrow(() -> new NotFoundException("Workspace not found"));
   }
 
   @Override

--- a/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginOwner.java
+++ b/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginOwner.java
@@ -1,0 +1,25 @@
+package com.prgrms.be02slack.util;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import com.prgrms.be02slack.member.entity.Role;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomLoginOwnerSecurityContextFactory.class)
+public @interface WithMockCustomLoginOwner {
+
+  long id() default 1L;
+
+  String email() default "test@test.com";
+
+  String name() default "test";
+
+  String displayName() default "test";
+
+  Role role() default Role.ROLE_OWNER;
+
+  long workspaceId() default 1L;
+}

--- a/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginOwnerSecurityContextFactory.java
+++ b/src/test/java/com/prgrms/be02slack/util/WithMockCustomLoginOwnerSecurityContextFactory.java
@@ -1,0 +1,44 @@
+package com.prgrms.be02slack.util;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.prgrms.be02slack.member.entity.Member;
+import com.prgrms.be02slack.security.MemberDetails;
+import com.prgrms.be02slack.workspace.entity.Workspace;
+
+public class WithMockCustomLoginOwnerSecurityContextFactory implements
+    WithSecurityContextFactory<WithMockCustomLoginOwner> {
+
+  @Override
+  public SecurityContext createSecurityContext(WithMockCustomLoginOwner annotation) {
+
+    final SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+
+    Workspace workspace = Workspace.createDefaultWorkspace();
+    ReflectionTestUtils.setField(workspace, "id", annotation.workspaceId());
+
+    Member member = Member.builder()
+        .email(annotation.email())
+        .name(annotation.name())
+        .displayName(annotation.displayName())
+        .role(annotation.role())
+        .workspace(workspace)
+        .build();
+    ReflectionTestUtils.setField(member, "id", annotation.id());
+
+    final MemberDetails memberDetails = MemberDetails.create(member);
+
+    final UsernamePasswordAuthenticationToken authenticationToken =
+        new UsernamePasswordAuthenticationToken(
+            memberDetails,
+            "password",
+            memberDetails.getAuthorities());
+
+    securityContext.setAuthentication(authenticationToken);
+    return securityContext;
+  }
+}

--- a/src/test/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiControllerTest.java
+++ b/src/test/java/com/prgrms/be02slack/workspace/controller/WorkspaceApiControllerTest.java
@@ -18,13 +18,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.MockBeans;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
@@ -32,19 +29,17 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.prgrms.be02slack.common.configuration.security.SecurityConfig;
+import com.prgrms.be02slack.util.ControllerSetUp;
+import com.prgrms.be02slack.util.WithMockCustomLoginMember;
+import com.prgrms.be02slack.util.WithMockCustomLoginOwner;
+import com.prgrms.be02slack.util.WithMockCustomLoginUser;
 import com.prgrms.be02slack.workspace.entity.Workspace;
 import com.prgrms.be02slack.workspace.service.WorkspaceService;
 
-@WebMvcTest(
-    controllers = WorkspaceApiController.class,
-    excludeAutoConfiguration = SecurityAutoConfiguration.class,
-    excludeFilters = {
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
-    })
+@WebMvcTest(controllers = WorkspaceApiController.class)
 @MockBeans({@MockBean(JpaMetamodelMappingContext.class)})
 @AutoConfigureRestDocs
-class WorkspaceApiControllerTest {
+class WorkspaceApiControllerTest extends ControllerSetUp {
 
   private static final String API_URL = "/api/v1/workspaces";
 
@@ -85,6 +80,7 @@ class WorkspaceApiControllerTest {
 
   @Nested
   @DisplayName("update 메서드는")
+  @WithMockCustomLoginOwner
   class DescribeUpdate {
 
     @Nested


### PR DESCRIPTION
workspace api의 경우 owner권한만 필요하기 때문에 기존 `WithMockCustomLoginMember` 를 참고하여, `WithMockCustomLoginOwner` 어노테이션을 만들어 적용하였습니다.